### PR TITLE
Enable RevApi to check the API for correct semantic versioning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,23 @@
           <entryPointClassPackage>io.jenkins.plugins.checks.assertions</entryPointClassPackage>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <configuration>
+          <versionFormat>[0-9.]*</versionFormat> 
+          <checkDependencies>false</checkDependencies>
+          <analysisConfiguration>
+            <revapi.ignore combine.children="append">
+              <item>
+                <regex>true</regex>
+                <code>java.missing.*</code>
+                <justification>Dependencies are not being checked, so they are reported as missing</justification>
+              </item>
+            </revapi.ignore>
+          </analysisConfiguration>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Our API is quite stable now, so it makes sense to enable the API checker. It ensures that we do not break other plugins accidentally, see [JENKINS-63295](https://issues.jenkins-ci.org/browse/JENKINS-63295) for details.