### PR TITLE
Enable an ArchUnit test that validates that there are no package cycles

### DIFF
--- a/src/test/java/io/jenkins/plugins/checks/PackageArchitectureTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/PackageArchitectureTest.java
@@ -1,0 +1,28 @@
+package io.jenkins.plugins.checks;
+
+import java.net.URL;
+
+import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeTests;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
+import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.Configurations.*;
+import static com.tngtech.archunit.library.plantuml.PlantUmlArchCondition.*;
+
+/**
+ * Checks the package architecture of this plugin.
+ *
+ * @author Ullrich Hafner
+ */
+@SuppressWarnings("hideutilityclassconstructor")
+@AnalyzeClasses(packages = "io.jenkins.plugins.checks..", importOptions = DoNotIncludeTests.class)
+class PackageArchitectureTest {
+    private static final URL PACKAGE_DESIGN = PackageArchitectureTest.class.getResource("/design.puml");
+
+    @ArchTest
+    static final ArchRule ADHERES_TO_PACKAGE_DESIGN
+            = classes().should(adhereToPlantUmlDiagram(PACKAGE_DESIGN,
+            consideringOnlyDependenciesInAnyPackage("io.jenkins.plugins.checks..")));
+}

--- a/src/test/resources/design.puml
+++ b/src/test/resources/design.puml
@@ -1,0 +1,14 @@
+@startuml
+
+skinparam componentStyle uml2
+skinparam component {
+  BorderColor #a0a0a0
+  BackgroundColor #f8f8f8
+}
+
+[API] <<..checks.api>>
+[Steps] <<..checks>>
+
+[Steps] --> [API]
+
+@enduml


### PR DESCRIPTION
Another small tool to keep the API well designed. It adds an architecture test that validates that there are no package cycles. 
The package design is specified in the PlantUml file `design.puml`. All classes must use only dependencies that are allowed by the package graph in that file. The package graph must be an acyclic directed graph. 