### PR TITLE
Add the ability to allow users to customize status checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ This plugin, along with it's [GitHub implementation](https://plugins.jenkins.io/
 
 ![GitHub Status](docs/images/github-status.png)
 
-By listening to the Jenkins builds, this plugin will automatically publish statuses (pending, in progress, and completed) to different SCM platforms based on the remote repository the build is using.
+This plugin defines extension points to publish statuses to different SCM platforms.
+
+It depends on the implementation to decide whether to skip them and what name to use.
+
+If enabled, the statuses will be published in different stages of a Jenkins build (enters the queue, checkouts, and completes).
 
 ### Pipeline Usage
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This plugin defines extension points to publish statuses to different SCM platfo
 
 It depends on the implementation to decide whether to skip them and what name to use.
 
-If enabled, the statuses will be published in different stages of a Jenkins build (enters the queue, checkouts, and completes).
+If enabled, the statuses will be published in different stages of a Jenkins build (enters the queue, checkout, and completes).
 
 ### Pipeline Usage
 

--- a/docs/implementation-guide.md
+++ b/docs/implementation-guide.md
@@ -117,7 +117,7 @@ There are three methods in this interface:
 
 - `boolean isApplicable(Job<?, ?> job)`
 
-    Implement this method to return `true` if your implementation does not applicable to the `job`.
+    Implement this method to return `true` if your implementation is not applicable to the `job`.
     
 - `String getName(Job<?, ?> job)`
 

--- a/docs/implementation-guide.md
+++ b/docs/implementation-guide.md
@@ -101,3 +101,28 @@ public class GitHubChecksPublisher extends ChecksPublisher {
 The checks parameters are provided by consumers through the models in the [`api` package](https://github.com/jenkinsci/checks-api-plugin/tree/master/src/main/java/io/jenkins/plugins/checks/api).
 You can check the [consumers guide](consumers-guide.md#checks-parameters) for more details.
 
+## Check Status
+
+The status checks will be published for three different stages of a build:
+- Queued
+- Checkout
+- Completed
+
+When publishing the checks, this plugin will use the above API as a consumer.
+
+To control the properties of status checks,
+you need to implement the interface `StatusChecksProperties`.
+
+There are three methods in this interface:
+
+- `boolean isApplicable(Job<?, ?> job)`
+
+    Implement this method to return `true` if your implementation does not applicable to the `job`.
+    
+- `String getName(Job<?, ?> job)`
+
+    Implement this method to return the name of the status checks for the `job`.
+    
+- `boolean isSkip(Job<?, ?> job)`
+
+   Implement this method to return `true` if you want to skip publishing status checks for the `job`.

--- a/docs/implementation-guide.md
+++ b/docs/implementation-guide.md
@@ -117,7 +117,7 @@ There are three methods in this interface:
 
 - `boolean isApplicable(Job<?, ?> job)`
 
-    Implement this method to return `true` if your implementation is not applicable to the `job`.
+    Implement this method to return `true` if your implementation is applicable to the `job`.
     
 - `String getName(Job<?, ?> job)`
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <properties>
     <java.level>8</java.level>
-    <revision>1.0.1</revision>
+    <revision>2.0.0</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <!-- Jenkins Plug-in Dependencies Versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <properties>
     <java.level>8</java.level>
-    <revision>2.0.0</revision>
+    <revision>1.1.0</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <!-- Jenkins Plug-in Dependencies Versions -->
@@ -108,6 +108,11 @@
                 <code>java.annotation.removed</code>
                 <annotationType>org.kohsuke.accmod.Restricted</annotationType>
                 <justification>Beta restriction should be safe to remove.</justification>
+              </item>
+              <item>
+                <code>java.class.removed</code>
+                <old>class io.jenkins.plugins.checks.BuildStatusChecksPublisher</old>
+                <justification>BuildStatusChecksPublisher has no consumers, should be safe to move.</justification>
               </item>
             </revapi.ignore>
           </analysisConfiguration>

--- a/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
@@ -28,20 +28,20 @@ import io.jenkins.plugins.util.JenkinsFacade;
  * A publisher which publishes different statuses through the checks API based on the stage of the {@link Queue.Item}
  * or {@link Run}.
  */
-final public class BuildStatusChecksPublisher {
+public final class BuildStatusChecksPublisher {
     private static final JenkinsFacade JENKINS = new JenkinsFacade();
     private static final StatusChecksProperties DEFAULT_PROPERTIES = new DefaultStatusCheckProperties();
 
     private static void publish(final ChecksPublisher publisher, final ChecksStatus status,
                                 final ChecksConclusion conclusion, final String name) {
-            publisher.publish(new ChecksDetailsBuilder()
-                    .withName(name)
-                    .withStatus(status)
-                    .withConclusion(conclusion)
-                    .build());
+        publisher.publish(new ChecksDetailsBuilder()
+                .withName(name)
+                .withStatus(status)
+                .withConclusion(conclusion)
+                .build());
     }
 
-    private static StatusChecksProperties findProperties(Job<?, ?> job) {
+    private static StatusChecksProperties findProperties(final Job<?, ?> job) {
         return JENKINS.getExtensionsFor(StatusChecksProperties.class)
                 .stream()
                 .filter(p -> p.isApplicable(job))

--- a/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
@@ -73,9 +73,9 @@ final public class BuildStatusChecksPublisher {
 
             final Job job = (Job)wi.task;
             final StatusChecksProperties properties = findProperties(job);
-            if (!properties.isSkipped()) {
+            if (!properties.isSkipped(job)) {
                 publish(ChecksPublisherFactory.fromJob(job, TaskListener.NULL), ChecksStatus.QUEUED,
-                        ChecksConclusion.NONE, properties.getName());
+                        ChecksConclusion.NONE, properties.getName(job));
             }
         }
     }
@@ -101,9 +101,9 @@ final public class BuildStatusChecksPublisher {
                                @CheckForNull final SCMRevisionState pollingBaseline) {
             final StatusChecksProperties properties = findProperties(run.getParent());
 
-            if (!properties.isSkipped()) {
+            if (!properties.isSkipped(run.getParent())) {
                 publish(ChecksPublisherFactory.fromRun(run, listener), ChecksStatus.IN_PROGRESS, ChecksConclusion.NONE,
-                        properties.getName());
+                        properties.getName(run.getParent()));
             }
         }
     }
@@ -128,9 +128,9 @@ final public class BuildStatusChecksPublisher {
         public void onCompleted(final Run run, @CheckForNull final TaskListener listener) {
             final StatusChecksProperties properties = findProperties(run.getParent());
 
-            if (!properties.isSkipped()) {
+            if (!properties.isSkipped(run.getParent())) {
                 publish(ChecksPublisherFactory.fromRun(run, listener), ChecksStatus.COMPLETED, extractConclusion(run),
-                        properties.getName());
+                        properties.getName(run.getParent()));
             }
         }
 
@@ -156,22 +156,5 @@ final public class BuildStatusChecksPublisher {
                 throw new IllegalStateException("Unsupported run result: " + result);
             }
         }
-    }
-}
-
-class DefaultStatusCheckProperties implements StatusChecksProperties {
-    @Override
-    public boolean isApplicable(final Job<?, ?> job) {
-        return false;
-    }
-
-    @Override
-    public String getName() {
-        return "Jenkins";
-    }
-
-    @Override
-    public boolean isSkipped() {
-        return false;
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
@@ -73,7 +73,7 @@ final public class BuildStatusChecksPublisher {
 
             final Job job = (Job)wi.task;
             final StatusChecksProperties properties = findProperties(job);
-            if (!properties.isSkipped(job)) {
+            if (!properties.isSkip(job)) {
                 publish(ChecksPublisherFactory.fromJob(job, TaskListener.NULL), ChecksStatus.QUEUED,
                         ChecksConclusion.NONE, properties.getName(job));
             }
@@ -101,7 +101,7 @@ final public class BuildStatusChecksPublisher {
                                @CheckForNull final SCMRevisionState pollingBaseline) {
             final StatusChecksProperties properties = findProperties(run.getParent());
 
-            if (!properties.isSkipped(run.getParent())) {
+            if (!properties.isSkip(run.getParent())) {
                 publish(ChecksPublisherFactory.fromRun(run, listener), ChecksStatus.IN_PROGRESS, ChecksConclusion.NONE,
                         properties.getName(run.getParent()));
             }
@@ -128,7 +128,7 @@ final public class BuildStatusChecksPublisher {
         public void onCompleted(final Run run, @CheckForNull final TaskListener listener) {
             final StatusChecksProperties properties = findProperties(run.getParent());
 
-            if (!properties.isSkipped(run.getParent())) {
+            if (!properties.isSkip(run.getParent())) {
                 publish(ChecksPublisherFactory.fromRun(run, listener), ChecksStatus.COMPLETED, extractConclusion(run),
                         properties.getName(run.getParent()));
             }

--- a/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
@@ -1,4 +1,4 @@
-package io.jenkins.plugins.checks;
+package io.jenkins.plugins.checks.status;
 
 import java.io.File;
 
@@ -22,21 +22,25 @@ import io.jenkins.plugins.checks.api.ChecksDetails.ChecksDetailsBuilder;
 import io.jenkins.plugins.checks.api.ChecksPublisher;
 import io.jenkins.plugins.checks.api.ChecksPublisherFactory;
 import io.jenkins.plugins.checks.api.ChecksStatus;
+import io.jenkins.plugins.util.JenkinsFacade;
 
 /**
  * A publisher which publishes different statuses through the checks API based on the stage of the {@link Queue.Item}
  * or {@link Run}.
  */
-public class BuildStatusChecksPublisher {
-    private static final String CHECKS_NAME = "Jenkins";
+final public class BuildStatusChecksPublisher {
+    private static final JenkinsFacade jenkins = new JenkinsFacade();
+    private static final StatusChecksProperties defaultProperties = new DefaultStatusCheckProperties();
 
     private static void publish(final ChecksPublisher publisher, final ChecksStatus status,
-                                final ChecksConclusion conclusion) {
-        publisher.publish(new ChecksDetailsBuilder()
-                .withName(CHECKS_NAME)
-                .withStatus(status)
-                .withConclusion(conclusion)
-                .build());
+                                final ChecksConclusion conclusion, final StatusChecksProperties properties) {
+        if (properties.isActive()) {
+            publisher.publish(new ChecksDetailsBuilder()
+                    .withName(properties.getName())
+                    .withStatus(status)
+                    .withConclusion(conclusion)
+                    .build());
+        }
     }
 
     /**
@@ -62,7 +66,12 @@ public class BuildStatusChecksPublisher {
             }
 
             publish(ChecksPublisherFactory.fromJob((Job)wi.task, TaskListener.NULL),
-                    ChecksStatus.QUEUED, ChecksConclusion.NONE);
+                    ChecksStatus.QUEUED, ChecksConclusion.NONE,
+                    jenkins.getExtensionsFor(StatusChecksProperties.class)
+                            .stream()
+                            .filter(properties -> properties.isApplicable((Job)wi.task))
+                            .findFirst()
+                            .orElse(defaultProperties));
         }
     }
 
@@ -85,7 +94,12 @@ public class BuildStatusChecksPublisher {
         public void onCheckout(final Run<?, ?> run, final SCM scm, final FilePath workspace,
                                final TaskListener listener, @CheckForNull final File changelogFile,
                                @CheckForNull final SCMRevisionState pollingBaseline) {
-            publish(ChecksPublisherFactory.fromRun(run, listener), ChecksStatus.IN_PROGRESS, ChecksConclusion.NONE);
+            publish(ChecksPublisherFactory.fromRun(run, listener), ChecksStatus.IN_PROGRESS, ChecksConclusion.NONE,
+                    jenkins.getExtensionsFor(StatusChecksProperties.class)
+                            .stream()
+                            .filter(properties -> properties.isApplicable(run))
+                            .findFirst()
+                            .orElse(defaultProperties));
         }
     }
 
@@ -107,7 +121,12 @@ public class BuildStatusChecksPublisher {
          */
         @Override
         public void onCompleted(final Run run, @CheckForNull final TaskListener listener) {
-            publish(ChecksPublisherFactory.fromRun(run, listener), ChecksStatus.COMPLETED, extractConclusion(run));
+            publish(ChecksPublisherFactory.fromRun(run, listener), ChecksStatus.COMPLETED, extractConclusion(run),
+                    jenkins.getExtensionsFor(StatusChecksProperties.class)
+                            .stream()
+                            .filter(properties -> properties.isApplicable(run))
+                            .findFirst()
+                            .orElse(defaultProperties));
         }
 
         private ChecksConclusion extractConclusion(final Run<?, ?> run) {
@@ -132,5 +151,27 @@ public class BuildStatusChecksPublisher {
                 throw new IllegalStateException("Unsupported run result: " + result);
             }
         }
+    }
+}
+
+class DefaultStatusCheckProperties implements StatusChecksProperties {
+    @Override
+    public String getName() {
+        return "Jenkins";
+    }
+
+    @Override
+    public boolean isActive() {
+        return true;
+    }
+
+    @Override
+    public boolean isApplicable(final Job<?, ?> job) {
+        return false;
+    }
+
+    @Override
+    public boolean isApplicable(final Run<?, ?> run) {
+        return false;
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
@@ -50,6 +50,6 @@ class DefaultStatusCheckProperties implements StatusChecksProperties {
 
     @Override
     public boolean isSkip(final Job<?, ?> job) {
-        return false;
+        return true;
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
@@ -21,14 +21,35 @@ public interface StatusChecksProperties extends ExtensionPoint {
     /**
      * Returns the name of the status check.
      *
+     * @param job
+     *         A jenkins job.
      * @return the name of the status check
      */
-    String getName();
+    String getName(final Job<?, ?> job);
 
     /**
      * Returns if skip publishing status checks.
      *
+     * @param job
+     *         A jenkins job.
      * @return true if skip
      */
-    boolean isSkipped();
+    boolean isSkipped(final Job<?, ?> job);
+}
+
+class DefaultStatusCheckProperties implements StatusChecksProperties {
+    @Override
+    public boolean isApplicable(final Job<?, ?> job) {
+        return false;
+    }
+
+    @Override
+    public String getName(final Job<?, ?> job) {
+        return "Jenkins";
+    }
+
+    @Override
+    public boolean isSkipped(final Job<?, ?> job) {
+        return false;
+    }
 }

--- a/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
@@ -16,7 +16,7 @@ public interface StatusChecksProperties extends ExtensionPoint {
      *         A jenkins job.
      * @return true if applicable
      */
-    boolean isApplicable(final Job<?, ?> job);
+    boolean isApplicable(Job<?, ?> job);
 
     /**
      * Returns the name of the status check.
@@ -25,7 +25,7 @@ public interface StatusChecksProperties extends ExtensionPoint {
      *         A jenkins job.
      * @return the name of the status check
      */
-    String getName(final Job<?, ?> job);
+    String getName(Job<?, ?> job);
 
     /**
      * Returns if skip publishing status checks.
@@ -34,7 +34,7 @@ public interface StatusChecksProperties extends ExtensionPoint {
      *         A jenkins job.
      * @return true if skip
      */
-    boolean isSkip(final Job<?, ?> job);
+    boolean isSkip(Job<?, ?> job);
 }
 
 class DefaultStatusCheckProperties implements StatusChecksProperties {

--- a/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
@@ -34,7 +34,7 @@ public interface StatusChecksProperties extends ExtensionPoint {
      *         A jenkins job.
      * @return true if skip
      */
-    boolean isSkipped(final Job<?, ?> job);
+    boolean isSkip(final Job<?, ?> job);
 }
 
 class DefaultStatusCheckProperties implements StatusChecksProperties {
@@ -49,7 +49,7 @@ class DefaultStatusCheckProperties implements StatusChecksProperties {
     }
 
     @Override
-    public boolean isSkipped(final Job<?, ?> job) {
+    public boolean isSkip(final Job<?, ?> job) {
         return false;
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
@@ -1,0 +1,12 @@
+package io.jenkins.plugins.checks.status;
+
+import hudson.ExtensionPoint;
+import hudson.model.Job;
+import hudson.model.Run;
+
+public interface StatusChecksProperties extends ExtensionPoint {
+    String getName();
+    boolean isActive();
+    boolean isApplicable(final Job<?, ?> job);
+    boolean isApplicable(final Run<?, ?> run);
+}

--- a/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
@@ -2,11 +2,33 @@ package io.jenkins.plugins.checks.status;
 
 import hudson.ExtensionPoint;
 import hudson.model.Job;
-import hudson.model.Run;
 
+/**
+ * Properties that controls status checks.
+ *
+ * When no implementations is provided for a job, a {@link DefaultStatusCheckProperties} will be used.
+ */
 public interface StatusChecksProperties extends ExtensionPoint {
-    String getName();
-    boolean isActive();
+    /**
+     * Returns if the implementation is applicable for the {@code job}.
+     *
+     * @param job
+     *         A jenkins job.
+     * @return true if applicable
+     */
     boolean isApplicable(final Job<?, ?> job);
-    boolean isApplicable(final Run<?, ?> run);
+
+    /**
+     * Returns the name of the status check.
+     *
+     * @return the name of the status check
+     */
+    String getName();
+
+    /**
+     * Returns if skip publishing status checks.
+     *
+     * @return true if skip
+     */
+    boolean isSkipped();
 }

--- a/src/main/java/io/jenkins/plugins/checks/status/package-info.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Provides default Findbugs annotations.
+ */
+@DefaultAnnotation(NonNull.class)
+package io.jenkins.plugins.checks.status;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/src/test/resources/design.puml
+++ b/src/test/resources/design.puml
@@ -8,9 +8,11 @@ skinparam component {
 
 [API] <<..checks.api>>
 [Steps] <<..checks.steps>>
+[Status] <<..checks.status>>
 [Checks] <<..checks>>
 
 [Steps] --> [API]
+[Status] --> [API]
 [Checks] --> [API]
 
 @enduml


### PR DESCRIPTION
Add the ability to allow users to customize status checks like name or disable the status checks feature.

The new added interface `StatusChecksProperties` share common properties between SCM implementations. Thus, the SCM implementations (like Git SCM or Branch Source SCM) can add behaviors that implement this interface to change properties of status checks.

- [x] Add implementations
  - See https://github.com/jenkinsci/github-checks-plugin/pull/66