### PR TITLE
workflow-job & workflow-cps should be in test, not compile, scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-job</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <!-- node -->


### PR DESCRIPTION
Avoid unnecessary plugin dependencies. Corrects a mistake in #7.