### PR TITLE
Add property for unstable builds to conclude as NEUTRAL

### DIFF
--- a/docs/implementation-guide.md
+++ b/docs/implementation-guide.md
@@ -126,3 +126,7 @@ There are three methods in this interface:
 - `boolean isSkip(Job<?, ?> job)`
 
    Implement this method to return `true` if you want to skip publishing status checks for the `job`.
+
+- `boolean isUnstableNeutral(Job<?, ?> job)`
+
+   Implement this method to return `true` if you want `UNSTABLE` builds to result in `NEUTRAL` conclusions, or false to result in `FAILURE`.

--- a/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
@@ -132,7 +132,7 @@ public final class BuildStatusChecksPublisher {
                 publish(
                     ChecksPublisherFactory.fromRun(run, listener),
                     ChecksStatus.COMPLETED,
-                    extractConclusion(run, properties.isUnstableNeutral()),
+                    extractConclusion(run, properties.isUnstableNeutral(run.getParent())),
                     properties.getName(run.getParent())
                 );
             }

--- a/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
@@ -62,7 +62,7 @@ class DefaultStatusCheckProperties implements StatusChecksProperties {
     }
 
     @Override
-    public boolean isUnstableNeutral(Job<?, ?> job) {
+    public boolean isUnstableNeutral(final Job<?, ?> job) {
         return false;
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
@@ -35,6 +35,14 @@ public interface StatusChecksProperties extends ExtensionPoint {
      * @return true if skip
      */
     boolean isSkip(Job<?, ?> job);
+
+    /**
+     * Returns true if unsable builds result in NEUTRAL conclusion, else it will result in FAILURE. Default is false.
+     * @param job
+     *         A jenkins job.
+     * @return true if UNSTABLE should be treated as a NEUTRAL.
+     */
+    boolean isUnstableNeutral(Job<?, ?> job);
 }
 
 class DefaultStatusCheckProperties implements StatusChecksProperties {
@@ -51,5 +59,10 @@ class DefaultStatusCheckProperties implements StatusChecksProperties {
     @Override
     public boolean isSkip(final Job<?, ?> job) {
         return true;
+    }
+
+    @Override
+    public boolean isUnstableNeutral(Job<?, ?> job) {
+        return false;
     }
 }

--- a/src/main/resources/io/jenkins/plugins/checks/steps/PublishChecksStep/help-status.html
+++ b/src/main/resources/io/jenkins/plugins/checks/steps/PublishChecksStep/help-status.html
@@ -1,3 +1,4 @@
 <div>
-    The status of the check, can be "QUEUED", "IN_PROGRESS", or "COMPLETED". By default, "COMPLETED" will be used.
+    The status of the check, can be "QUEUED", "IN_PROGRESS", or "COMPLETED". By default, "COMPLETED" will be
+    used.
 </div>


### PR DESCRIPTION
This adds a new property `isUnstableNeutral` which is configurable by plugin implementers. When set to `true` the plugin will return a `NEUTRAL` conclusion if the build result was `UNSTABLE` or better, when set to false it will continue to return `FAILURE` as it does today. The default property is set to `false` to preserve behavior compatibility.