### PR TITLE
Migrate to AbstractStatusChecksProperties class.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
   <properties>
     <java.level>8</java.level>
     <revision>1.2.0</revision>
-    <changelist>-SNAPSHOT</changelist>
 
     <!-- Jenkins Plug-in Dependencies Versions -->
     <plugin-util-api.version>1.5.0</plugin-util-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <properties>
     <java.level>8</java.level>
-    <revision>1.1.2</revision>
+    <revision>1.2.0</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <!-- Jenkins Plug-in Dependencies Versions -->

--- a/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
@@ -1,0 +1,37 @@
+package io.jenkins.plugins.checks.status;
+
+import hudson.ExtensionPoint;
+import hudson.model.Job;
+
+/**
+ * Extension points for implementations to provide status checks properties.
+ *
+ * When no implementations is provided for a job, a {@link DefaultStatusCheckProperties} will be used.
+ */
+public abstract class AbstractStatusChecksProperties implements StatusChecksProperties, ExtensionPoint {
+    @Override
+    public abstract boolean isApplicable(Job<?, ?> job);
+
+    @Override
+    public abstract String getName(Job<?, ?> job);
+
+    @Override
+    public abstract boolean isSkip(Job<?, ?> job);
+}
+
+class DefaultStatusCheckProperties extends AbstractStatusChecksProperties {
+    @Override
+    public boolean isApplicable(final Job<?, ?> job) {
+        return false;
+    }
+
+    @Override
+    public String getName(final Job<?, ?> job) {
+        return "Jenkins";
+    }
+
+    @Override
+    public boolean isSkip(final Job<?, ?> job) {
+        return true;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
@@ -8,15 +8,33 @@ import hudson.model.Job;
  *
  * When no implementations is provided for a job, a {@link DefaultStatusCheckProperties} will be used.
  */
-public abstract class AbstractStatusChecksProperties implements StatusChecksProperties, ExtensionPoint {
-    @Override
+public abstract class AbstractStatusChecksProperties implements ExtensionPoint {
+    /**
+     * Returns if the implementation is applicable for the {@code job}.
+     *
+     * @param job
+     *         A jenkins job.
+     * @return true if applicable
+     */
     public abstract boolean isApplicable(Job<?, ?> job);
 
-    @Override
+    /**
+     * Returns the name of the status check.
+     *
+     * @param job
+     *         A jenkins job.
+     * @return the name of the status check
+     */
     public abstract String getName(Job<?, ?> job);
 
-    @Override
-    public abstract boolean isSkip(Job<?, ?> job);
+    /**
+     * Returns if skip publishing status checks.
+     *
+     * @param job
+     *         A jenkins job.
+     * @return true if skip
+     */
+    public abstract boolean isSkipped(Job<?, ?> job);
 }
 
 class DefaultStatusCheckProperties extends AbstractStatusChecksProperties {
@@ -31,7 +49,7 @@ class DefaultStatusCheckProperties extends AbstractStatusChecksProperties {
     }
 
     @Override
-    public boolean isSkip(final Job<?, ?> job) {
+    public boolean isSkipped(final Job<?, ?> job) {
         return true;
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
@@ -10,7 +10,7 @@ import hudson.model.Job;
  */
 public abstract class AbstractStatusChecksProperties implements ExtensionPoint {
     /**
-     * Returns if the implementation is applicable for the {@code job}.
+     * Returns whether the implementation is applicable for the {@code job}.
      *
      * @param job
      *         A jenkins job.
@@ -28,7 +28,7 @@ public abstract class AbstractStatusChecksProperties implements ExtensionPoint {
     public abstract String getName(Job<?, ?> job);
 
     /**
-     * Returns if skip publishing status checks.
+     * Returns whether to skip publishing status checks.
      *
      * @param job
      *         A jenkins job.

--- a/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
@@ -30,7 +30,7 @@ import io.jenkins.plugins.util.JenkinsFacade;
  */
 public final class BuildStatusChecksPublisher {
     private static final JenkinsFacade JENKINS = new JenkinsFacade();
-    private static final StatusChecksProperties DEFAULT_PROPERTIES = new DefaultStatusCheckProperties();
+    private static final AbstractStatusChecksProperties DEFAULT_PROPERTIES = new DefaultStatusCheckProperties();
 
     private static void publish(final ChecksPublisher publisher, final ChecksStatus status,
                                 final ChecksConclusion conclusion, final String name) {
@@ -46,7 +46,13 @@ public final class BuildStatusChecksPublisher {
                 .stream()
                 .filter(p -> p.isApplicable(job))
                 .findFirst()
-                .orElse(DEFAULT_PROPERTIES);
+                .orElse(
+                        JENKINS.getExtensionsFor(AbstractStatusChecksProperties.class)
+                        .stream()
+                        .filter(p -> p.isApplicable(job))
+                        .findFirst()
+                        .orElse(DEFAULT_PROPERTIES)
+                );
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.checks.status;
 
 import java.io.File;
+import java.util.Optional;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
@@ -41,18 +42,20 @@ public final class BuildStatusChecksPublisher {
                 .build());
     }
 
-    private static StatusChecksProperties findProperties(final Job<?, ?> job) {
+    @Deprecated
+    private static Optional<StatusChecksProperties> findDeprecatedProperties(final Job<?, ?> job) {
         return JENKINS.getExtensionsFor(StatusChecksProperties.class)
                 .stream()
                 .filter(p -> p.isApplicable(job))
+                .findFirst();
+    }
+
+    private static AbstractStatusChecksProperties findProperties(final Job<?, ?> job) {
+        return JENKINS.getExtensionsFor(AbstractStatusChecksProperties.class)
+                .stream()
+                .filter(p -> p.isApplicable(job))
                 .findFirst()
-                .orElse(
-                        JENKINS.getExtensionsFor(AbstractStatusChecksProperties.class)
-                        .stream()
-                        .filter(p -> p.isApplicable(job))
-                        .findFirst()
-                        .orElse(DEFAULT_PROPERTIES)
-                );
+                .orElse(DEFAULT_PROPERTIES);
     }
 
     /**
@@ -78,10 +81,19 @@ public final class BuildStatusChecksPublisher {
             }
 
             final Job job = (Job)wi.task;
-            final StatusChecksProperties properties = findProperties(job);
-            if (!properties.isSkip(job)) {
-                publish(ChecksPublisherFactory.fromJob(job, TaskListener.NULL), ChecksStatus.QUEUED,
-                        ChecksConclusion.NONE, properties.getName(job));
+            Optional<StatusChecksProperties> deprecatedProperties = findDeprecatedProperties(job);
+            if (deprecatedProperties.isPresent()) {
+                if (!deprecatedProperties.get().isSkip(job)) {
+                    publish(ChecksPublisherFactory.fromJob(job, TaskListener.NULL), ChecksStatus.QUEUED,
+                            ChecksConclusion.NONE, deprecatedProperties.get().getName(job));
+                }
+            }
+            else {
+                final AbstractStatusChecksProperties properties = findProperties(job);
+                if (!properties.isSkipped(job)) {
+                    publish(ChecksPublisherFactory.fromJob(job, TaskListener.NULL), ChecksStatus.QUEUED,
+                            ChecksConclusion.NONE, properties.getName(job));
+                }
             }
         }
     }
@@ -105,11 +117,20 @@ public final class BuildStatusChecksPublisher {
         public void onCheckout(final Run<?, ?> run, final SCM scm, final FilePath workspace,
                                final TaskListener listener, @CheckForNull final File changelogFile,
                                @CheckForNull final SCMRevisionState pollingBaseline) {
-            final StatusChecksProperties properties = findProperties(run.getParent());
-
-            if (!properties.isSkip(run.getParent())) {
-                publish(ChecksPublisherFactory.fromRun(run, listener), ChecksStatus.IN_PROGRESS, ChecksConclusion.NONE,
-                        properties.getName(run.getParent()));
+            final Job job = run.getParent();
+            final Optional<StatusChecksProperties> deprecatedProperties = findDeprecatedProperties(job);
+            if (deprecatedProperties.isPresent()) {
+                if (!deprecatedProperties.get().isSkip(job)) {
+                    publish(ChecksPublisherFactory.fromRun(run, listener), ChecksStatus.IN_PROGRESS,
+                            ChecksConclusion.NONE, deprecatedProperties.get().getName(job));
+                }
+            }
+            else {
+                final AbstractStatusChecksProperties properties = findProperties(job);
+                if (!properties.isSkipped(job)) {
+                    publish(ChecksPublisherFactory.fromRun(run, listener), ChecksStatus.IN_PROGRESS,
+                            ChecksConclusion.NONE, properties.getName(job));
+                }
             }
         }
     }
@@ -132,11 +153,20 @@ public final class BuildStatusChecksPublisher {
          */
         @Override
         public void onCompleted(final Run run, @CheckForNull final TaskListener listener) {
-            final StatusChecksProperties properties = findProperties(run.getParent());
-
-            if (!properties.isSkip(run.getParent())) {
-                publish(ChecksPublisherFactory.fromRun(run, listener), ChecksStatus.COMPLETED, extractConclusion(run),
-                        properties.getName(run.getParent()));
+            final Job job = run.getParent();
+            final Optional<StatusChecksProperties> deprecatedProperties = findDeprecatedProperties(job);
+            if (deprecatedProperties.isPresent()) {
+                if (!deprecatedProperties.get().isSkip(job)) {
+                    publish(ChecksPublisherFactory.fromRun(run, listener), ChecksStatus.COMPLETED,
+                            extractConclusion(run), deprecatedProperties.get().getName(job));
+                }
+            }
+            else {
+                final AbstractStatusChecksProperties properties = findProperties(job);
+                if (!properties.isSkipped(job)) {
+                    publish(ChecksPublisherFactory.fromRun(run, listener), ChecksStatus.COMPLETED,
+                            extractConclusion(run), properties.getName(job));
+                }
             }
         }
 

--- a/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
@@ -7,7 +7,10 @@ import hudson.model.Job;
  * Properties that controls status checks.
  *
  * When no implementations is provided for a job, a {@link DefaultStatusCheckProperties} will be used.
+ *
+ * @deprecated The interface is incompatible for future changes, use {@link AbstractStatusChecksProperties} instead
  */
+@Deprecated
 public interface StatusChecksProperties extends ExtensionPoint {
     /**
      * Returns if the implementation is applicable for the {@code job}.
@@ -35,21 +38,4 @@ public interface StatusChecksProperties extends ExtensionPoint {
      * @return true if skip
      */
     boolean isSkip(Job<?, ?> job);
-}
-
-class DefaultStatusCheckProperties implements StatusChecksProperties {
-    @Override
-    public boolean isApplicable(final Job<?, ?> job) {
-        return false;
-    }
-
-    @Override
-    public String getName(final Job<?, ?> job) {
-        return "Jenkins";
-    }
-
-    @Override
-    public boolean isSkip(final Job<?, ?> job) {
-        return true;
-    }
 }

--- a/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
@@ -3,6 +3,8 @@ package io.jenkins.plugins.checks.status;
 import hudson.ExtensionPoint;
 import hudson.model.Job;
 
+import java.sql.Statement;
+
 /**
  * Properties that controls status checks.
  *

--- a/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java
@@ -3,8 +3,6 @@ package io.jenkins.plugins.checks.status;
 import hudson.ExtensionPoint;
 import hudson.model.Job;
 
-import java.sql.Statement;
-
 /**
  * Properties that controls status checks.
  *


### PR DESCRIPTION
The current interface [`StatusChecksProperties`](https://github.com/jenkinsci/checks-api-plugin/blob/6273f4e6e4cd248f0e7c4f447022a2088cd8e0fd/src/main/java/io/jenkins/plugins/checks/status/StatusChecksProperties.java#L11) is incompatible for future changes (e.g. https://github.com/jenkinsci/checks-api-plugin/pull/51), so this PR migrates to `AbstractStatusChecksProperties` (although the default method can be used, since the implementation is still in our control, we'd better refactor it).

In order to make the migration smooth without breaking the compatibility (if necessary), here is the plan or some steps for it:
1. deprecate the `StatusChecksProperties` interface and add the `AbstractStatusChecksProperties` class (this PR)
2. change [`BuildStatusChecksPublisher`](https://github.com/jenkinsci/checks-api-plugin/blob/6273f4e6e4cd248f0e7c4f447022a2088cd8e0fd/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java#L31) to allow it accepts implementations for both the old interface and new abstract class
3. release the checks api plugin with this PR
4. refactor the GitHub implementation [`GitHubStatusChecksProperties`](https://github.com/jenkinsci/github-checks-plugin/blob/master/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksProperties.java) to extend `AbstractStatusChecksProperties`
5. release the github checks plugin with the refacotring in (4)
6. wait for some time to ensure the updating by users and then remove `StatusChecksProperties` interface

