### PR TITLE
Fix POM version and RevApi configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
   <properties>
     <java.level>8</java.level>
     <revision>1.2.0</revision>
+    <changelist>-SNAPSHOT</changelist>
 
     <!-- Jenkins Plug-in Dependencies Versions -->
     <plugin-util-api.version>1.6.0</plugin-util-api.version>
@@ -107,6 +108,7 @@
         <groupId>org.revapi</groupId>
         <artifactId>revapi-maven-plugin</artifactId>
         <configuration>
+          <versionFormat>\d+\.\d+\.\d+</versionFormat>
           <analysisConfiguration>
             <revapi.ignore combine.children="append">
               <item>


### PR DESCRIPTION
In #49 the `<changelist>` tag has been removed from the `pom.xml` which breaks the build. This PR restores the tag.

Additionally, RevApi needs to be configured to not pick up intermediate releases from the incrementals repository. We always need to compare the API to the latest release in Jenkins update center.

This PR fixes #56. 