### PR TITLE
Jenkinsfile: only build on linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,8 @@
  See the documentation for more options:
  https://github.com/jenkins-infra/pipeline-library/
 */
-buildPlugin(useAci: true)
+def configurations = [
+    [ platform: "linux", jdk: "8", jenkins: null ],
+    [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ]
+]
+buildPlugin(configurations: configurations, useAci: true)


### PR DESCRIPTION
the windows build on the community servers is not very reliable and we already have GitHub builds for windows which is more stable and enough. 

cc @mrginglymus 