### PR TITLE
Add failure to title

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
@@ -184,7 +184,8 @@ class FlowExecutionAnalyzer {
         if (node instanceof StepNode) {
             StepDescriptor d = ((StepNode) node).getDescriptor();
             return d != null && d.getFunctionName().equals("stage");
-        } else {
+        }
+        else {
             return false;
         }
     }
@@ -199,8 +200,7 @@ class FlowExecutionAnalyzer {
         List<FlowNode> enclosingBlocks = new ArrayList<>();
         for (FlowNode enclosing : node.getEnclosingBlocks()) {
             if (enclosing != null && enclosing.getAction(LabelAction.class) != null) {
-                if (isStageNode(enclosing) ||
-                        (enclosing.getAction(ThreadNameAction.class) != null)) {
+                if (isStageNode(enclosing) || enclosing.getAction(ThreadNameAction.class) != null) {
                     enclosingBlocks.add(enclosing);
                 }
             }
@@ -218,10 +218,11 @@ class FlowExecutionAnalyzer {
             if (threadNameAction != null) {
                 // If we're on a parallel branch with the same name as the previous (inner) node, that generally
                 // means we're in a Declarative parallel stages situation, so don't add the redundant branch name.
-                if (names.isEmpty() || !threadNameAction.getThreadName().equals(names.get(names.size()-1))) {
+                if (names.isEmpty() || !threadNameAction.getThreadName().equals(names.get(names.size() - 1))) {
                     names.add(threadNameAction.getThreadName());
                 }
-            } else if (labelAction != null) {
+            }
+            else if (labelAction != null) {
                 names.add(labelAction.getDisplayName());
             }
         }

--- a/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
@@ -20,7 +20,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -28,7 +27,6 @@ import java.util.Stack;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 class FlowExecutionAnalyzer {
 

--- a/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
@@ -172,7 +172,7 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
         // Details 6, p1s1 has finished and emitted unstable
         details = checksDetails.get(6);
         assertThat(details.getOutput()).isPresent().get().satisfies(output -> {
-            assertThat(output.getTitle()).isPresent().get().isEqualTo("Unstable");
+            assertThat(output.getTitle()).isPresent().get().isEqualTo("p1s1: warning in 'unstable' step");
             assertThat(output.getSummary()).isPresent().get().asString().isEqualToIgnoringNewLines(""
                     + "### `In parallel / p1 / p1s1 / Set stage result to unstable`\n"
                     + "Warning in `unstable` step, with arguments `something went wrong`.\n"
@@ -195,7 +195,7 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
         assertThat(details.getStatus()).isEqualTo(ChecksStatus.COMPLETED);
         assertThat(details.getConclusion()).isEqualTo(ChecksConclusion.FAILURE);
         assertThat(details.getOutput()).isPresent().get().satisfies(output -> {
-            assertThat(output.getTitle()).isPresent().get().isEqualTo("Failure");
+            assertThat(output.getTitle()).isPresent().get().isEqualTo("Fails: error in 'archiveArtifacts' step");
             assertThat(output.getSummary()).isPresent().get().asString().matches(Pattern.compile(".*"
                     + "### `In parallel / p1 / p1s1 / Set stage result to unstable`\\s+"
                     + "Warning in `unstable` step, with arguments `something went wrong`\\.\\s+"

--- a/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
@@ -229,6 +229,26 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
         });
     }
 
+    @Test
+    public void shouldPublishSimplePipeline() {
+        PROPERTIES.setApplicable(true);
+        PROPERTIES.setSkipped(false);
+        PROPERTIES.setName("Test Status");
+        WorkflowJob job = createPipeline();
+
+        job.setDefinition(new CpsFlowDefinition(""
+                + "node {\n"
+                + "  echo 'Hello, world'"
+                + "}", true));
+
+        buildWithResult(job, Result.SUCCESS);
+
+        List<ChecksDetails> checksDetails = PUBLISHER_FACTORY.getPublishedChecks();
+
+        ChecksDetails details = checksDetails.get(1);
+        assertThat(details.getOutput()).isPresent().get().satisfies(output -> assertThat(output.getTitle()).isPresent().get().isEqualTo("Success"));
+    }
+
     static class ChecksProperties extends AbstractStatusChecksProperties {
         private boolean applicable;
         private boolean skipped;

--- a/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
@@ -229,6 +229,9 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
         });
     }
 
+    /**
+     * Validates the a simple successful pipeline works.
+     */
     @Test
     public void shouldPublishSimplePipeline() {
         PROPERTIES.setApplicable(true);

--- a/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
@@ -172,7 +172,7 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
         // Details 6, p1s1 has finished and emitted unstable
         details = checksDetails.get(6);
         assertThat(details.getOutput()).isPresent().get().satisfies(output -> {
-            assertThat(output.getTitle()).isPresent().get().isEqualTo("p1s1: warning in 'unstable' step");
+            assertThat(output.getTitle()).isPresent().get().isEqualTo("In parallel/p1/p1s1: warning in 'unstable' step");
             assertThat(output.getSummary()).isPresent().get().asString().isEqualToIgnoringNewLines(""
                     + "### `In parallel / p1 / p1s1 / Set stage result to unstable`\n"
                     + "Warning in `unstable` step, with arguments `something went wrong`.\n"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21194782/107099420-86c53e80-6809-11eb-8b29-f99770f066dd.png)

![image](https://user-images.githubusercontent.com/21194782/107098284-c3436b00-6806-11eb-967e-8b8069d677ba.png)

![image](https://user-images.githubusercontent.com/21194782/107099443-980e4b00-6809-11eb-8e75-43c24fa69282.png)

Happy to change the naming:

`$branchLabel: $status in $step step`

I've tested quite a few cases and all seems to work, imported some code from the junit plugin so we can get the stage names from a child `FlowNode`

The test pipeline doesn't have any nested stages or parallel but the tests do and it ends up being:

'stage/parallelBranch/stage'

the test text:
'In parallel/p1/p1s1: warning in 'unstable' step'

@mrginglymus FYI