### PR TITLE
Ignore stage graph output while checking out

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
@@ -150,7 +150,7 @@ public final class BuildStatusChecksPublisher {
                                final TaskListener listener, @CheckForNull final File changelogFile,
                                @CheckForNull final SCMRevisionState pollingBaseline) {
             getChecksName(run).ifPresent(checksName -> publish(ChecksPublisherFactory.fromRun(run, listener),
-                    ChecksStatus.IN_PROGRESS, ChecksConclusion.NONE, checksName, getOutput(run)));
+                    ChecksStatus.IN_PROGRESS, ChecksConclusion.NONE, checksName, null));
         }
     }
 


### PR DESCRIPTION
A quick fix for https://issues.jenkins.io/browse/JENKINS-64813

checking out pipeline library will trigger our listener although there is no flow graph available, so an NEP occurs.