### PR TITLE
Add status checks property to conclude unstable builds as neutral ones

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <properties>
     <java.level>8</java.level>
-    <revision>1.4.2</revision>
+    <revision>1.5.0</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <!-- Jenkins Plug-in Dependencies Versions -->

--- a/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
@@ -37,7 +37,7 @@ public abstract class AbstractStatusChecksProperties implements ExtensionPoint {
     public abstract boolean isSkipped(Job<?, ?> job);
 
     /**
-     * Returns whether to conclude a unstable build as {@link io.jenkins.plugins.checks.api.ChecksConclusion#NEUTRAL},
+     * Whether to conclude an unstable build as {@link io.jenkins.plugins.checks.api.ChecksConclusion#NEUTRAL},
      * else it would be concluded as {@link io.jenkins.plugins.checks.api.ChecksConclusion#FAILURE};
      * the default is false.
      *

--- a/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
@@ -35,6 +35,19 @@ public abstract class AbstractStatusChecksProperties implements ExtensionPoint {
      * @return true if skip
      */
     public abstract boolean isSkipped(Job<?, ?> job);
+
+    /**
+     * Returns whether to conclude a unstable build as {@link io.jenkins.plugins.checks.api.ChecksConclusion#NEUTRAL},
+     * else it would be concluded as {@link io.jenkins.plugins.checks.api.ChecksConclusion#FAILURE};
+     * the default is false.
+     *
+     * @param job
+     *         A jenkins job.
+     * @return false to treat a unstable build as failure.
+     */
+    public boolean isUnstableBuildNeutral(Job<?, ?> job) {
+        return false;
+    }
 }
 
 class DefaultStatusCheckProperties extends AbstractStatusChecksProperties {

--- a/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
@@ -183,10 +183,14 @@ public final class BuildStatusChecksPublisher {
                 throw new IllegalStateException("No result when the run completes, run: " + run.toString());
             }
 
+            Job<?, ?> job = run.getParent();
             if (result.isBetterOrEqualTo(Result.SUCCESS)) {
                 return ChecksConclusion.SUCCESS;
             }
-            else if (result.isBetterOrEqualTo(Result.UNSTABLE) || result.isBetterOrEqualTo(Result.FAILURE)) {
+            else if (result.isBetterOrEqualTo(Result.UNSTABLE) && findProperties(job).isUnstableBuildNeutral(job)) {
+                return ChecksConclusion.NEUTRAL;
+            }
+            else if (result.isBetterOrEqualTo(Result.FAILURE)) {
                 return ChecksConclusion.FAILURE;
             }
             else if (result.isBetterOrEqualTo(Result.NOT_BUILT)) {


### PR DESCRIPTION
context: https://github.com/jenkinsci/checks-api-plugin/issues/46