### PR TITLE
Handle failure in publish invocation

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/steps/WithChecksStep.java
+++ b/src/main/java/io/jenkins/plugins/checks/steps/WithChecksStep.java
@@ -209,8 +209,9 @@ public class WithChecksStep extends Step implements Serializable {
                                     .withTitle("Failed")
                                     .withText(t.toString()).build());
                 }
-                publish(context, builder);
-                context.onFailure(t);
+                if (publish(context, builder)) {
+                    context.onFailure(t);
+                }
             }
         }
     }

--- a/src/main/java/io/jenkins/plugins/checks/steps/WithChecksStep.java
+++ b/src/main/java/io/jenkins/plugins/checks/steps/WithChecksStep.java
@@ -147,10 +147,16 @@ public class WithChecksStep extends Step implements Serializable {
                 return false;
             }
 
-            ChecksPublisherFactory.fromRun(run, listener)
-                    .publish(builder.withDetailsURL(DisplayURLProvider.get().getRunURL(run))
-                            .build());
-            return true;
+            try {
+                ChecksPublisherFactory.fromRun(run, listener)
+                        .publish(builder.withDetailsURL(DisplayURLProvider.get().getRunURL(run))
+                                .build());
+                return true;
+            }
+            catch (Exception e) {
+                context.onFailure(e);
+                return false;
+            }
         }
 
         class WithChecksCallBack extends BodyExecutionCallback {


### PR DESCRIPTION
From what I think I can glean from the stack trace/reading similar code, an unhandled exception in any of the `BodyExecutionCallback` might lead to zombie jobs on executors. This manifested itself when the `publish` at the start of a `withChecks` step failed because of a merge conflict. The overall job aborted succesfully, but the three outstanding parallel stages continued to block their executors and required manual cleanup.