### PR TITLE
Add option to suppress log in job summary

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
@@ -56,7 +56,7 @@ public abstract class AbstractStatusChecksProperties implements ExtensionPoint {
      *         A jenkins job.
      * @return true if logs should be suppressed from checks output.
      */
-    public boolean isSuppressLogs(Job<?, ?> job) {
+    public boolean isSuppressLogs(final Job<?, ?> job) {
         return false;
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
@@ -48,6 +48,17 @@ public abstract class AbstractStatusChecksProperties implements ExtensionPoint {
     public boolean isUnstableBuildNeutral(final Job<?, ?> job) {
         return false;
     }
+
+    /**
+     * Returns whether to suppress log output in the {@link io.jenkins.plugins.checks.status.FlowExecutionAnalyzer}.
+     *
+     * @param job
+     *         A jenkins job.
+     * @return true if logs should be suppressed from checks output.
+     */
+    public boolean isSuppressLogs(Job<?, ?> job) {
+        return false;
+    }
 }
 
 class DefaultStatusCheckProperties extends AbstractStatusChecksProperties {

--- a/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
@@ -99,7 +99,7 @@ public final class BuildStatusChecksPublisher {
     }
 
     static ChecksOutput getOutput(final Run run, final FlowExecution execution) {
-        return new FlowExecutionAnalyzer(run, execution).extractOutput();
+        return new FlowExecutionAnalyzer(run, execution, findProperties(run.getParent()).isSuppressLogs(run.getParent())).extractOutput();
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
@@ -35,10 +35,12 @@ class FlowExecutionAnalyzer {
     private final Run<?, ?> run;
     private final FlowExecution execution;
     private final Stack<Integer> indentationStack = new Stack<>();
+    private final boolean suppressLogs;
 
-    FlowExecutionAnalyzer(final Run<?, ?> run, final FlowExecution execution) {
+    FlowExecutionAnalyzer(final Run<?, ?> run, final FlowExecution execution, final boolean suppressLogs) {
         this.run = run;
         this.execution = execution;
+        this.suppressLogs = suppressLogs;
     }
 
     private static Optional<String> getStageOrBranchName(final FlowNode node) {
@@ -117,11 +119,12 @@ class FlowExecutionAnalyzer {
         nodeTextBuilder.append(String.join("", Collections.nCopies(indentationStack.size() + 1, "  ")));
         if (warningAction == null) {
             nodeTextBuilder.append(String.format("**Error**: *%s*", errorAction.getDisplayName()));
-            String log = getLog(flowNode);
-            if (StringUtils.isNotBlank(log)) {
-                nodeSummaryBuilder.append(String.format("```%n%s%n```%n<details>%n<summary>Build log</summary>%n%n```%n%s%n```%n</details>",
-                        errorAction.getDisplayName(),
-                        log));
+            nodeSummaryBuilder.append(String.format("```%n%s%n```%n", errorAction.getDisplayName()));
+            if (!suppressLogs) {
+                String log = getLog(flowNode);
+                if (StringUtils.isNotBlank(log)) {
+                    nodeSummaryBuilder.append(String.format("<details>%n<summary>Build log</summary>%n%n```%n%s%n```%n</details>", log));
+                }
             }
         }
         else {

--- a/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
@@ -115,6 +115,7 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
     public void shouldPublishStageDetails() {
         PROPERTIES.setApplicable(true);
         PROPERTIES.setSkipped(false);
+        PROPERTIES.setSuppressLogs(false);
         PROPERTIES.setName("Test Status");
         WorkflowJob job = createPipeline();
 

--- a/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
@@ -356,7 +356,7 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
         }
 
         @Override
-        public boolean isSuppressLogs(Job<?, ?> job) {
+        public boolean isSuppressLogs(final Job<?, ?> job) {
             return suppressLogs;
         }
     }

--- a/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
@@ -13,6 +13,7 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.After;
 import org.junit.Test;
+import org.junit.internal.Checks;
 import org.jvnet.hudson.test.TestExtension;
 
 import java.util.List;
@@ -213,8 +214,7 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
                     + "Archiving artifacts\\s+"
                     + "‘oh dear’ doesn’t match anything\\s+"
                     + "```\\s+"
-                    + "</details>"
-                    + ".*", Pattern.DOTALL));
+                    + "</details>\\s+", Pattern.DOTALL));
             assertThat(output.getText()).isPresent().asString().matches(Pattern.compile(".*"
                     + "  \\* Simple Stage \\*\\([^)]+\\)\\*\n"
                     + "  \\* In parallel \\*\\([^)]+\\)\\*\n"
@@ -225,6 +225,71 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
                     + "    \\* p2 \\*\\([^)]+\\)\\*\n"
                     + "  \\* Fails \\*\\([^)]+\\)\\*\n"
                     + "    \\*\\*Error\\*\\*: \\*No artifacts found that match the file pattern \"oh dear\". Configuration error\\?\\*\n.*",
+                    Pattern.DOTALL));
+        });
+    }
+
+    /**
+     * Test checks output includes pipeline details, but not logs, when requested.
+     */
+    @Test
+    public void shouldPublishStageDetailsWithoutLogsIfRequested() {
+        PROPERTIES.setApplicable(true);
+        PROPERTIES.setSkipped(false);
+        PROPERTIES.setName("Test Status");
+        PROPERTIES.setSuppressLogs(true);
+        WorkflowJob job = createPipeline();
+
+        job.setDefinition(new CpsFlowDefinition(""
+                + "node {\n"
+                + "  stage('Simple Stage') {\n"
+                + "  }\n"
+                + "  stage('In parallel') {\n"
+                + "    parallel 'p1': {\n"
+                + "      stage('p1s1') {\n"
+                + "        unstable('something went wrong')\n"
+                + "      }\n"
+                + "      stage('p1s2') {\n"
+                + "      }\n"
+                + "    }, 'p2': {}\n"
+                + "  }\n"
+                + "  stage('Fails') {\n"
+                + "    archiveArtifacts artifacts: 'oh dear', fingerprint: true\n"
+                + "  }\n"
+                + "}", true));
+
+        buildWithResult(job, Result.FAILURE);
+
+        List<ChecksDetails> checksDetails = PUBLISHER_FACTORY.getPublishedChecks();
+
+        assertThat(checksDetails).hasSize(9);
+
+        ChecksDetails details = checksDetails.get(8);
+        assertThat(details.getStatus()).isEqualTo(ChecksStatus.COMPLETED);
+        assertThat(details.getConclusion()).isEqualTo(ChecksConclusion.FAILURE);
+        assertThat(details.getOutput()).isPresent().get().satisfies(output -> {
+            assertThat(output.getTitle()).isPresent().get().isEqualTo("Fails: error in 'archiveArtifacts' step");
+            assertThat(output.getSummary()).isPresent().get().asString().matches(Pattern.compile(".*"
+                    + "### `In parallel / p1 / p1s1 / Set stage result to unstable`\\s+"
+                    + "Warning in `unstable` step, with arguments `something went wrong`\\.\\s+"
+                    + "```\\s+"
+                    + "something went wrong\\s+"
+                    + "```\\s+"
+                    + "### `Fails / Archive the artifacts`\\s+"
+                    + "Error in `archiveArtifacts` step\\.\\s+"
+                    + "```\\s+"
+                    + "No artifacts found that match the file pattern \"oh dear\"\\. Configuration error\\?\\s+"
+                    + "```\\s+", Pattern.DOTALL));
+            assertThat(output.getText()).isPresent().asString().matches(Pattern.compile(".*"
+                            + "  \\* Simple Stage \\*\\([^)]+\\)\\*\n"
+                            + "  \\* In parallel \\*\\([^)]+\\)\\*\n"
+                            + "    \\* p1 \\*\\([^)]+\\)\\*\n"
+                            + "      \\* p1s1 \\*\\([^)]+\\)\\*\n"
+                            + "        \\*\\*Unstable\\*\\*: \\*something went wrong\\*\n"
+                            + "      \\* p1s2 \\*\\([^)]+\\)\\*\n"
+                            + "    \\* p2 \\*\\([^)]+\\)\\*\n"
+                            + "  \\* Fails \\*\\([^)]+\\)\\*\n"
+                            + "    \\*\\*Error\\*\\*: \\*No artifacts found that match the file pattern \"oh dear\". Configuration error\\?\\*\n.*",
                     Pattern.DOTALL));
         });
     }
@@ -256,6 +321,7 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
         private boolean applicable;
         private boolean skipped;
         private String name;
+        private boolean suppressLogs;
 
         public void setApplicable(final boolean applicable) {
             this.applicable = applicable;
@@ -267,6 +333,10 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
 
         public void setName(final String name) {
             this.name = name;
+        }
+
+        public void setSuppressLogs(final boolean suppressLogs) {
+            this.suppressLogs = suppressLogs;
         }
 
         @Override
@@ -282,6 +352,11 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
         @Override
         public boolean isSkipped(final Job<?, ?> job) {
             return skipped;
+        }
+
+        @Override
+        public boolean isSuppressLogs(Job<?, ?> job) {
+            return suppressLogs;
         }
     }
 }


### PR DESCRIPTION
Fixes #92 

I ummed and ahhed a bit over whether to have `suppressLogs` vs `includeLogs` but I went with `true` == override default behaviour (with the assumption that most people _do_ want logs).