### PR TITLE
JENKINS-65262 Avoid holding queue lock when updating GitHub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,12 @@
               </item>
               <item>
                 <regex>true</regex>
+                <code>java.annotation.*</code>
+                <annotation>@edu.umd.cs.findbugs.annotations.*</annotation>
+                <justification>Annotation should be safe to change.</justification>
+              </item>
+              <item>
+                <regex>true</regex>
                 <code>java.missing.*</code>
                 <justification>Dependencies are not being checked, so they are reported as missing</justification>
               </item>

--- a/spotbugs-exclusion-filter.xml
+++ b/spotbugs-exclusion-filter.xml
@@ -1,0 +1,2 @@
+<FindBugsFilter>
+</FindBugsFilter>

--- a/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
@@ -134,18 +134,24 @@ public final class BuildStatusChecksPublisher {
          * </p>
          */
         @Override
-        @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
         public void onEnterWaiting(final Queue.WaitingItem wi) {
             if (!(wi.task instanceof Job)) {
                 return;
             }
 
             final Job<?, ?> job = (Job<?, ?>) wi.task;
+            //noinspection Convert2Lambda https://github.com/spotbugs/spotbugs/issues/724
             getChecksName(job).ifPresent(checksName ->
-                    Computer.threadPoolForRemoting.submit(() -> {
-                        ChecksPublisher publisher = ChecksPublisherFactory.fromJob(job, TaskListener.NULL);
-                        publish(publisher, ChecksStatus.QUEUED, ChecksConclusion.NONE, checksName, null);
-                    }));
+                    Computer.threadPoolForRemoting.submit(
+                            new Runnable() {
+                                @Override
+                                @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
+                                public void run() {
+                                    ChecksPublisher publisher = ChecksPublisherFactory.fromJob(job, TaskListener.NULL);
+                                    publish(publisher, ChecksStatus.QUEUED, ChecksConclusion.NONE, checksName, null);
+                                }
+                            }
+                    ));
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.checks.status;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Computer;
@@ -133,6 +134,7 @@ public final class BuildStatusChecksPublisher {
          * </p>
          */
         @Override
+        @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
         public void onEnterWaiting(final Queue.WaitingItem wi) {
             if (!(wi.task instanceof Job)) {
                 return;
@@ -140,12 +142,10 @@ public final class BuildStatusChecksPublisher {
 
             final Job<?, ?> job = (Job<?, ?>) wi.task;
             getChecksName(job).ifPresent(checksName ->
-                Computer.threadPoolForRemoting.submit(() ->
-                    {
+                    Computer.threadPoolForRemoting.submit(() -> {
                         ChecksPublisher publisher = ChecksPublisherFactory.fromJob(job, TaskListener.NULL);
                         publish(publisher, ChecksStatus.QUEUED, ChecksConclusion.NONE, checksName, null);
-                    }
-                ));
+                    }));
         }
     }
 

--- a/src/test/java/io/jenkins/plugins/checks/api/TruncatedStringTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/api/TruncatedStringTest.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.checks.api;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 @SuppressWarnings({"VisibilityModifier", "MissingJavadocMethod"})
 @RunWith(Parameterized.class)
+@SuppressFBWarnings("NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR")
 public class TruncatedStringTest {
     private static final String MESSAGE = "Truncated";  // length 9
 

--- a/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.checks.status;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -26,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * accordingly.
  */
 @SuppressWarnings("PMD.AddEmptyString")
+@SuppressFBWarnings("NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR")
 public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest {
 
     /**


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

https://issues.jenkins.io/browse/JENKINS-65262?focusedCommentId=407061&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-407061

Basically a deadlock can occur preventing builds from starting...

See equivalent code in github-branch-source: https://github.com/jenkinsci/github-branch-source-plugin/blob/2b68b4b8b14afa36ee5e243ed8630e2c01a86e2c/src/main/java/org/jenkinsci/plugins/github_branch_source/GitHubBuildStatusNotification.java#L231

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
