### PR TITLE
JENKINS-65262 Add ability to disable graph analyzer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <properties>
     <java.level>8</java.level>
-    <revision>1.6.3</revision>
+    <revision>1.7.0</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <!-- Jenkins Plug-in Dependencies Versions -->

--- a/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
@@ -59,6 +59,18 @@ public abstract class AbstractStatusChecksProperties implements ExtensionPoint {
     public boolean isSuppressLogs(final Job<?, ?> job) {
         return false;
     }
+
+    /**
+     * Returns whether to suppress progress updates from the {@link io.jenkins.plugins.checks.status.FlowExecutionAnalyzer}.
+     * Queued, Checkout and Completed will still run but not 'onNewHead'
+     *
+     * @param job
+     *         A jenkins job.
+     * @return true if progress updates should be skipped.
+     */
+    public boolean isSkipProgressUpdates(final Job<?, ?> job) {
+        return false;
+    }
 }
 
 class DefaultStatusCheckProperties extends AbstractStatusChecksProperties {

--- a/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
@@ -255,7 +255,7 @@ public final class BuildStatusChecksPublisher {
             Job<?, ?> job = run.getParent();
             if (!findProperties(job).isSkipProgressUpdates(job)) {
                 getChecksName(run).ifPresent(checksName -> publish(ChecksPublisherFactory.fromRun(run, TaskListener.NULL),
-                    ChecksStatus.IN_PROGRESS, ChecksConclusion.NONE, checksName, getOutput(run, node.getExecution())));
+                        ChecksStatus.IN_PROGRESS, ChecksConclusion.NONE, checksName, getOutput(run, node.getExecution())));
             }
 
         }

--- a/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
@@ -252,8 +252,11 @@ public final class BuildStatusChecksPublisher {
                 return;
             }
 
-            getChecksName(run).ifPresent(checksName -> publish(ChecksPublisherFactory.fromRun(run, TaskListener.NULL),
+            Job<?, ?> job = run.getParent();
+            if (!findProperties(job).isSkipProgressUpdates(job)) {
+                getChecksName(run).ifPresent(checksName -> publish(ChecksPublisherFactory.fromRun(run, TaskListener.NULL),
                     ChecksStatus.IN_PROGRESS, ChecksConclusion.NONE, checksName, getOutput(run, node.getExecution())));
+            }
 
         }
     }


### PR DESCRIPTION
Relates to https://issues.jenkins.io/browse/JENKINS-65262

and https://github.com/jenkinsci/github-branch-source-plugin/pull/406#issuecomment-811955211

basically we're getting rate limited and it's preventing new builds starting and causing us lots of pain.

We will still get queued, in progress and completed done (which will have the full output).

I think this should still be good for us, let's see what the performance is like

@mrginglymus fyi