### PR TITLE
Update plugin parent POM

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [8, 11]
+        java: [11]
         os: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.3</version>
+    <version>1.2</version>
   </extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,7 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.2</version>
+    <version>1.3</version>
   </extension>
 </extensions>
-

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>5.18.0</version>
+    <version>5.24.0</version>
     <relativePath />
   </parent>
 
@@ -18,13 +18,12 @@
   <description>Defines an API for Jenkins to publish checks to SCM platforms.</description>
 
   <properties>
-    <java.level>8</java.level>
     <revision>1.7.3</revision>
     <changelist>-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 
     <!-- Jenkins Plug-in Dependencies Versions -->
     <plugin-util-api.version>2.14.0</plugin-util-api.version>
-    <pipeline-stage-step.version>2.5</pipeline-stage-step.version>
   </properties>
 
   <licenses>
@@ -36,9 +35,9 @@
 
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
   </scm>
 
@@ -93,7 +92,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>pipeline-stage-step</artifactId>
-      <version>${pipeline-stage-step.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- steps -->


### PR DESCRIPTION
I have been attempting to run PCT tests in `jenkinsci/bom` against Java 17 and newer versions of PCT, and this plugin is running into failures because its parent POM is too old. This PR updates the parent POM to the latest build toolchain from jenkinsci/analysis-pom-plugin#446 to facilitate Java 17 compatibility testing and PCT updates in `jenkinsci/bom`.