### PR TITLE
Bump Plugin Utilities API from 2.14.0 to 2.16.0

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suppressions PUBLIC "-//Checkstyle//DTD SuppressionFilter Configuration 1.0//EN" "https://checkstyle.org/dtds/suppressions_1_0.dtd">
+<suppressions>
+  <suppress checks="RedundantModifierCheck" files="WithChecksStepITest.java" />
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,13 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <suppressionsLocation>${maven.multiModuleProjectDirectory}/checkstyle-suppressions.xml</suppressionsLocation>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-assertions-generator-maven-plugin</artifactId>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,6 @@
     <!-- Jenkins Plug-in Dependencies Versions -->
     <plugin-util-api.version>2.16.0</plugin-util-api.version>
     <testcontainers.version>1.17.1</testcontainers.version>
-
-    <checkstyle.skip>true</checkstyle.skip> <!-- TODO temporary, just for incremental build -->
   </properties>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,8 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 
     <!-- Jenkins Plug-in Dependencies Versions -->
-    <plugin-util-api.version>2.14.0</plugin-util-api.version>
+    <plugin-util-api.version>2.16.0</plugin-util-api.version>
+    <testcontainers.version>1.17.1</testcontainers.version>
   </properties>
 
   <licenses>
@@ -79,6 +80,31 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ssh-credentials</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ssh-slaves</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
     <!-- Jenkins Plug-in Dependencies Versions -->
     <plugin-util-api.version>2.16.0</plugin-util-api.version>
     <testcontainers.version>1.17.1</testcontainers.version>
+
+    <checkstyle.skip>true</checkstyle.skip> <!-- TODO temporary, just for incremental build -->
   </properties>
 
   <licenses>

--- a/src/test/java/io/jenkins/plugins/checks/ArchitectureTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/ArchitectureTest.java
@@ -20,7 +20,7 @@ class ArchitectureTest {
     static final ArchRule NO_JENKINS_INSTANCE_CALL = PluginArchitectureRules.NO_JENKINS_INSTANCE_CALL;
 
     @ArchTest
-    static final ArchRule NO_PUBLIC_TEST_CLASSES = ((ClassesShouldConjunction) PluginArchitectureRules.NO_PUBLIC_TEST_CLASSES)
+    static final ArchRule NO_PUBLIC_TEST_CLASSES = ((ClassesShouldConjunction) ArchitectureRules.NO_PUBLIC_TEST_CLASSES)
             .andShould().notBeAnnotatedWith(RunWith.class); // Allow for JUnit4 tests.
 
     @ArchTest

--- a/src/test/java/io/jenkins/plugins/checks/api/TruncatedStringTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/api/TruncatedStringTest.java
@@ -16,10 +16,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Test behavior of the {@link TruncatedString}.
  */
 @SuppressWarnings({"VisibilityModifier", "MissingJavadocMethod"})
-@SuppressFBWarnings("NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR")
 class TruncatedStringTest {
     private static final String MESSAGE = "Truncated";  // length 9
 
+    @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "Called by JUnit")
     private static Stream<Arguments> parameters() {
         return Stream.of(
                 Arguments.of(false, false),

--- a/src/test/java/io/jenkins/plugins/checks/api/TruncatedStringTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/api/TruncatedStringTest.java
@@ -1,12 +1,13 @@
 package io.jenkins.plugins.checks.api;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -15,51 +16,26 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Test behavior of the {@link TruncatedString}.
  */
 @SuppressWarnings({"VisibilityModifier", "MissingJavadocMethod"})
-@RunWith(Parameterized.class)
 @SuppressFBWarnings("NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR")
-public class TruncatedStringTest {
+class TruncatedStringTest {
     private static final String MESSAGE = "Truncated";  // length 9
 
-    /**
-     * Human readable test name.
-     */
-    @Parameterized.Parameter
-    public String testName;
-
-    /**
-     * Parameter for chunking on new lines (or not!).
-     */
-    @Parameterized.Parameter(1)
-    public boolean chunkOnNewlines;
-
-    /**
-     * Parameter for chunking on chars (or not!).
-     */
-    @Parameterized.Parameter(2)
-    public boolean chunkOnChars;
-
-    @Parameterized.Parameters(name = "{0}")
-    public static Object[][] parameters() {
-        return new Object[][]{
-                {"Chunks+Bytes", false, false},
-                {"Newlines+Bytes", true, false},
-                {"Chunks+Chars", false, true},
-                {"Newlines+Chars", true, true}
-        };
+    private static Stream<Arguments> parameters() {
+        return Stream.of(
+                Arguments.of(false, false),
+                Arguments.of(true, false),
+                Arguments.of(false, true),
+                Arguments.of(true, true));
     }
 
     private TruncatedString.Builder builder;
 
-    @Before
+    @BeforeEach
     public void makeBuilder() {
-        this.builder = new TruncatedString.Builder()
-                .withTruncationText(MESSAGE);
-        if (chunkOnNewlines) {
-            builder.setChunkOnNewlines();
-        }
+        this.builder = new TruncatedString.Builder().withTruncationText(MESSAGE);
     }
 
-    private String build(final int maxSize) {
+    private String build(final boolean chunkOnChars, final int maxSize) {
         return chunkOnChars ? builder.build().buildByChars(maxSize) : builder.build().buildByBytes(maxSize);
     }
 
@@ -67,91 +43,126 @@ public class TruncatedStringTest {
         return builder.build().toString();
     }
 
-    @Test
-    public void shouldBuildStrings() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void shouldBuildStrings(boolean chunkOnNewlines, boolean chunkOnChars) {
+        if (chunkOnNewlines) {
+            builder.setChunkOnNewlines();
+        }
         builder.addText("Hello\n");
         assertThat(buildRawString()).isEqualTo("Hello\n");
-        assertThat(build(1000)).isEqualTo("Hello\n");
+        assertThat(build(chunkOnChars, 1000)).isEqualTo("Hello\n");
         builder.addText(", world!");
         assertThat(buildRawString()).isEqualTo("Hello\n, world!");
-        assertThat(build(1000)).isEqualTo("Hello\n, world!");
+        assertThat(build(chunkOnChars, 1000)).isEqualTo("Hello\n, world!");
     }
 
-    @Test
-    public void shouldTruncateStrings() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void shouldTruncateStrings(boolean chunkOnNewlines, boolean chunkOnChars) {
+        if (chunkOnNewlines) {
+            builder.setChunkOnNewlines();
+        }
         builder.addText("xxxxxxxxx\n"); // 10
-        assertThat(build(20)).isEqualTo("xxxxxxxxx\n");
+        assertThat(build(chunkOnChars, 20)).isEqualTo("xxxxxxxxx\n");
         builder.addText("yyyy\n"); // 5, doesn't cause overflow
-        assertThat(build(20)).isEqualTo("xxxxxxxxx\nyyyy\n");
+        assertThat(build(chunkOnChars, 20)).isEqualTo("xxxxxxxxx\nyyyy\n");
         builder.addText("zzzzzz\n"); // 7, does cause overflow
-        assertThat(build(20)).isEqualTo("xxxxxxxxx\nTruncated");
+        assertThat(build(chunkOnChars, 20)).isEqualTo("xxxxxxxxx\nTruncated");
     }
 
-    @Test
-    public void shouldHandleEdgeCases() {
-        assertThat(build(10)).isEqualTo("");
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void shouldHandleEdgeCases(boolean chunkOnNewlines, boolean chunkOnChars) {
+        if (chunkOnNewlines) {
+            builder.setChunkOnNewlines();
+        }
+        assertThat(build(chunkOnChars, 10)).isEqualTo("");
         assertThat(buildRawString()).isEqualTo("");
         builder.addText("xxxxxxxxxxxxxx\n"); // 15
-        assertThat(build(10)).isEqualTo("Truncated");
+        assertThat(build(chunkOnChars, 10)).isEqualTo("Truncated");
         assertThatThrownBy(() -> {
-            build(5);
+            build(chunkOnChars, 5);
         }).isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Maximum length is less than truncation text.");
     }
 
-    @Test
-    public void shouldHandleReversedChunking() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void shouldHandleReversedChunking(boolean chunkOnNewlines, boolean chunkOnChars) {
+        if (chunkOnNewlines) {
+            builder.setChunkOnNewlines();
+        }
         builder.setTruncateStart();
         builder.addText("zzzz\n"); // 5
-        assertThat(build(20)).isEqualTo("zzzz\n");
+        assertThat(build(chunkOnChars, 20)).isEqualTo("zzzz\n");
         builder.addText("xxxx\n"); // 5, doesn't cause overflow
-        assertThat(build(20)).isEqualTo("zzzz\nxxxx\n");
+        assertThat(build(chunkOnChars, 20)).isEqualTo("zzzz\nxxxx\n");
         builder.addText("cccc\n"); // 5, doesn't cause overflow
-        assertThat(build(20)).isEqualTo("zzzz\nxxxx\ncccc\n");
+        assertThat(build(chunkOnChars, 20)).isEqualTo("zzzz\nxxxx\ncccc\n");
         builder.addText("aaaaaa\n"); // 7, does cause overflow
-        assertThat(build(20)).isEqualTo("Truncatedcccc\naaaaaa\n");
+        assertThat(build(chunkOnChars, 20)).isEqualTo("Truncatedcccc\naaaaaa\n");
     }
 
-    @Test
-    public void shouldHandleEdgeCasesReversed() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void shouldHandleEdgeCasesReversed(boolean chunkOnNewlines, boolean chunkOnChars) {
+        if (chunkOnNewlines) {
+            builder.setChunkOnNewlines();
+        }
         builder.setTruncateStart();
-        assertThat(build(10)).isEqualTo("");
+        assertThat(build(chunkOnChars, 10)).isEqualTo("");
         assertThat(buildRawString()).isEqualTo("");
         builder.addText("xxxxxxxxxxxxxx\n"); // 15
-        assertThat(build(10)).isEqualTo("Truncated");
+        assertThat(build(chunkOnChars, 10)).isEqualTo("Truncated");
         assertThatThrownBy(() -> {
-            build(5);
+            build(chunkOnChars, 5);
         }).isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Maximum length is less than truncation text.");
     }
 
-    @Test
-    public void shouldChunkNewlinesDifferently() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void shouldChunkNewlinesDifferently(boolean chunkOnNewlines, boolean chunkOnChars) {
+        if (chunkOnNewlines) {
+            builder.setChunkOnNewlines();
+        }
         builder.addText("xxxxxxxxxx"); // 10
         builder.addText("yyyyyyyyyyy"); // 11
-        assertThat(build(20)).isEqualTo(chunkOnNewlines ? "Truncated" : "xxxxxxxxxxTruncated");
+        assertThat(build(chunkOnChars, 20)).isEqualTo(chunkOnNewlines ? "Truncated" : "xxxxxxxxxxTruncated");
 
         makeBuilder();
+        if (chunkOnNewlines) {
+            builder.setChunkOnNewlines();
+        }
         builder.addText("wwww\n"); // 5
         builder.addText("xxxx\nyyyy\nzzzzz\n"); // 16
-        assertThat(build(20)).isEqualTo(chunkOnNewlines ? "wwww\nxxxx\nTruncated" : "wwww\nTruncated");
+        assertThat(build(chunkOnChars, 20)).isEqualTo(chunkOnNewlines ? "wwww\nxxxx\nTruncated" : "wwww\nTruncated");
     }
 
-    @Test
-    public void shouldTruncateByBytesOrChars() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void shouldTruncateByBytesOrChars(boolean chunkOnNewlines, boolean chunkOnChars) {
+        if (chunkOnNewlines) {
+            builder.setChunkOnNewlines();
+        }
         builder.addText("☃☃☃\n"); // 3 + 1
         assertThat(buildRawString().length()).isEqualTo(4);
         assertThat(buildRawString().getBytes(StandardCharsets.UTF_8).length).isEqualTo(10);
-        assertThat(build(20)).isEqualTo("☃☃☃\n");
+        assertThat(build(chunkOnChars, 20)).isEqualTo("☃☃☃\n");
 
         builder.addText("🕴️🕴️\n"); // 2 + 1
         assertThat(buildRawString().length()).isEqualTo(11);
         assertThat(buildRawString().getBytes(StandardCharsets.UTF_8).length).isEqualTo(25);
-        assertThat(build(20)).isEqualTo(chunkOnChars ? "☃☃☃\n🕴️🕴️\n" : "☃☃☃\nTruncated");
+        assertThat(build(chunkOnChars, 20)).isEqualTo(chunkOnChars ? "☃☃☃\n🕴️🕴️\n" : "☃☃☃\nTruncated");
     }
 
-    @Test
-    public void shouldHandleLongCharsInTruncationText() {
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void shouldHandleLongCharsInTruncationText(boolean chunkOnNewlines, boolean chunkOnChars) {
+        if (chunkOnNewlines) {
+            builder.setChunkOnNewlines();
+        }
         String truncationText = "E_TOO_MUCH_☃";
         assertThat(truncationText.length()).isEqualTo(12);
         assertThat(truncationText.getBytes(StandardCharsets.UTF_8).length).isEqualTo(14);
@@ -159,8 +170,8 @@ public class TruncatedStringTest {
         builder.withTruncationText(truncationText);
         builder.addText("xxxx\n"); // 5
         builder.addText("x\n"); // 2
-        assertThat(build(20)).isEqualTo("xxxx\nx\n");
+        assertThat(build(chunkOnChars, 20)).isEqualTo("xxxx\nx\n");
         builder.addText("xxxxxxxxxxxxxxx"); // 15
-        assertThat(build(20)).isEqualTo(chunkOnChars ? "xxxx\nx\nE_TOO_MUCH_☃" : "xxxx\nE_TOO_MUCH_☃");
+        assertThat(build(chunkOnChars, 20)).isEqualTo(chunkOnChars ? "xxxx\nx\nE_TOO_MUCH_☃" : "xxxx\nE_TOO_MUCH_☃");
     }
 }

--- a/src/test/java/io/jenkins/plugins/checks/api/TruncatedStringTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/api/TruncatedStringTest.java
@@ -45,7 +45,7 @@ class TruncatedStringTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void shouldBuildStrings(boolean chunkOnNewlines, boolean chunkOnChars) {
+    public void shouldBuildStrings(final boolean chunkOnNewlines, final boolean chunkOnChars) {
         if (chunkOnNewlines) {
             builder.setChunkOnNewlines();
         }
@@ -59,7 +59,7 @@ class TruncatedStringTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void shouldTruncateStrings(boolean chunkOnNewlines, boolean chunkOnChars) {
+    public void shouldTruncateStrings(final boolean chunkOnNewlines, final boolean chunkOnChars) {
         if (chunkOnNewlines) {
             builder.setChunkOnNewlines();
         }
@@ -73,7 +73,7 @@ class TruncatedStringTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void shouldHandleEdgeCases(boolean chunkOnNewlines, boolean chunkOnChars) {
+    public void shouldHandleEdgeCases(final boolean chunkOnNewlines, final boolean chunkOnChars) {
         if (chunkOnNewlines) {
             builder.setChunkOnNewlines();
         }
@@ -89,7 +89,7 @@ class TruncatedStringTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void shouldHandleReversedChunking(boolean chunkOnNewlines, boolean chunkOnChars) {
+    public void shouldHandleReversedChunking(final boolean chunkOnNewlines, final boolean chunkOnChars) {
         if (chunkOnNewlines) {
             builder.setChunkOnNewlines();
         }
@@ -106,7 +106,7 @@ class TruncatedStringTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void shouldHandleEdgeCasesReversed(boolean chunkOnNewlines, boolean chunkOnChars) {
+    public void shouldHandleEdgeCasesReversed(final boolean chunkOnNewlines, final boolean chunkOnChars) {
         if (chunkOnNewlines) {
             builder.setChunkOnNewlines();
         }
@@ -123,7 +123,7 @@ class TruncatedStringTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void shouldChunkNewlinesDifferently(boolean chunkOnNewlines, boolean chunkOnChars) {
+    public void shouldChunkNewlinesDifferently(final boolean chunkOnNewlines, final boolean chunkOnChars) {
         if (chunkOnNewlines) {
             builder.setChunkOnNewlines();
         }
@@ -142,7 +142,7 @@ class TruncatedStringTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void shouldTruncateByBytesOrChars(boolean chunkOnNewlines, boolean chunkOnChars) {
+    public void shouldTruncateByBytesOrChars(final boolean chunkOnNewlines, final boolean chunkOnChars) {
         if (chunkOnNewlines) {
             builder.setChunkOnNewlines();
         }
@@ -159,7 +159,7 @@ class TruncatedStringTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    public void shouldHandleLongCharsInTruncationText(boolean chunkOnNewlines, boolean chunkOnChars) {
+    public void shouldHandleLongCharsInTruncationText(final boolean chunkOnNewlines, final boolean chunkOnChars) {
         if (chunkOnNewlines) {
             builder.setChunkOnNewlines();
         }

--- a/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
@@ -33,14 +33,6 @@ import static org.assertj.core.api.Assertions.*;
 @SuppressFBWarnings("NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR")
 class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest {
 
-    /**
-     * Provide a {@link io.jenkins.plugins.checks.util.CapturingChecksPublisher} to capture details.
-     */
-    @TestExtension
-    public static class CapturingChecksPublisherTestExtension extends CapturingChecksPublisher.Factory {
-        // activate test extension
-    }
-
     private CapturingChecksPublisher.Factory getFactory() {
         return getJenkins().getInstance().getExtensionList(ChecksPublisherFactory.class)
                 .stream()
@@ -334,6 +326,14 @@ class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest 
 
         ChecksDetails details = checksDetails.get(1);
         assertThat(details.getOutput()).isPresent().get().satisfies(output -> assertThat(output.getTitle()).isPresent().get().isEqualTo("Success"));
+    }
+
+    /**
+     * Provide a {@link io.jenkins.plugins.checks.util.CapturingChecksPublisher} to capture details.
+     */
+    @TestExtension
+    public static class CapturingChecksPublisherTestExtension extends CapturingChecksPublisher.Factory {
+        // activate test extension
     }
 
     static class ChecksProperties extends AbstractStatusChecksProperties {

--- a/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
@@ -4,8 +4,8 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.TestExtension;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -18,6 +18,7 @@ import hudson.model.Run;
 
 import io.jenkins.plugins.checks.api.ChecksConclusion;
 import io.jenkins.plugins.checks.api.ChecksDetails;
+import io.jenkins.plugins.checks.api.ChecksPublisherFactory;
 import io.jenkins.plugins.checks.api.ChecksStatus;
 import io.jenkins.plugins.checks.util.CapturingChecksPublisher;
 import io.jenkins.plugins.util.IntegrationTestWithJenkinsPerTest;
@@ -30,27 +31,47 @@ import static org.assertj.core.api.Assertions.*;
  */
 @SuppressWarnings({"PMD.AddEmptyString", "checkstyle:LambdaBodyLength"})
 @SuppressFBWarnings("NP_NONNULL_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR")
-public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest {
+class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest {
 
     /**
      * Provide a {@link io.jenkins.plugins.checks.util.CapturingChecksPublisher} to capture details.
      */
     @TestExtension
-    public static final CapturingChecksPublisher.Factory PUBLISHER_FACTORY = new CapturingChecksPublisher.Factory();
+    public static class CapturingChecksPublisherTestExtension extends CapturingChecksPublisher.Factory {
+        // activate test extension
+    }
+
+    private CapturingChecksPublisher.Factory getFactory() {
+        return getJenkins().getInstance().getExtensionList(ChecksPublisherFactory.class)
+                .stream()
+                .filter(f -> f instanceof CapturingChecksPublisher.Factory)
+                .map(f -> (CapturingChecksPublisher.Factory) f)
+                .findAny()
+                .orElseThrow(() -> new AssertionError("No CapturingChecksPublisher registered as @TestExtension?"));
+    }
 
     /**
      * Clean captured checks between tests.
      */
-    @After
+    @AfterEach
     public void clearChecks() {
-        PUBLISHER_FACTORY.getPublishedChecks().clear();
+        getFactory().getPublishedChecks().clear();
     }
 
     /**
      * Provide inject an implementation of {@link AbstractStatusChecksProperties} to control the checks.
      */
     @TestExtension
-    public static final ChecksProperties PROPERTIES = new ChecksProperties();
+    public static class ChecksPropertiesTestExtension extends ChecksProperties {
+        // activate test extension
+    }
+
+    private ChecksProperties getProperties() {
+        return getJenkins().getInstance().getExtensionList(ChecksProperties.class)
+                .stream()
+                .findAny()
+                .orElseThrow(() -> new AssertionError("No ChecksProperties registered as @TestExtension?"));
+    }
 
     /**
      * Tests when the implementation of {@link AbstractStatusChecksProperties} is not applicable,
@@ -58,11 +79,11 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
      */
     @Test
     public void shouldNotPublishStatusWhenNotApplicable() {
-        PROPERTIES.setApplicable(false);
+        getProperties().setApplicable(false);
 
         buildSuccessfully(createFreeStyleProject());
 
-        assertThat(PUBLISHER_FACTORY.getPublishedChecks()).hasSize(0);
+        assertThat(getFactory().getPublishedChecks()).hasSize(0);
     }
 
     /**
@@ -70,13 +91,13 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
      */
     @Test
     public void shouldNotPublishStatusWhenSkipped() {
-        PROPERTIES.setApplicable(true);
-        PROPERTIES.setSkipped(true);
-        PROPERTIES.setName("Test Status");
+        getProperties().setApplicable(true);
+        getProperties().setSkipped(true);
+        getProperties().setName("Test Status");
 
         buildSuccessfully(createFreeStyleProject());
 
-        assertThat(PUBLISHER_FACTORY.getPublishedChecks()).hasSize(0);
+        assertThat(getFactory().getPublishedChecks()).hasSize(0);
     }
 
     /**
@@ -85,27 +106,27 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
      */
     @Test
     public void shouldPublishStatusWithProperties() {
-        PROPERTIES.setApplicable(true);
-        PROPERTIES.setSkipped(false);
-        PROPERTIES.setName("Test Status");
+        getProperties().setApplicable(true);
+        getProperties().setSkipped(false);
+        getProperties().setName("Test Status");
 
         buildSuccessfully(createFreeStyleProject());
 
-        assertThat(PUBLISHER_FACTORY.getPublishedChecks()).hasSize(3);
+        assertThat(getFactory().getPublishedChecks()).hasSize(3);
 
-        ChecksDetails details = PUBLISHER_FACTORY.getPublishedChecks().get(0);
+        ChecksDetails details = getFactory().getPublishedChecks().get(0);
 
         assertThat(details.getName()).isPresent().get().isEqualTo("Test Status");
         assertThat(details.getStatus()).isEqualTo(ChecksStatus.QUEUED);
         assertThat(details.getConclusion()).isEqualTo(ChecksConclusion.NONE);
 
-        details = PUBLISHER_FACTORY.getPublishedChecks().get(1);
+        details = getFactory().getPublishedChecks().get(1);
 
         assertThat(details.getName()).isPresent().get().isEqualTo("Test Status");
         assertThat(details.getStatus()).isEqualTo(ChecksStatus.IN_PROGRESS);
         assertThat(details.getConclusion()).isEqualTo(ChecksConclusion.NONE);
 
-        details = PUBLISHER_FACTORY.getPublishedChecks().get(2);
+        details = getFactory().getPublishedChecks().get(2);
 
         assertThat(details.getName()).isPresent().get().isEqualTo("Test Status");
         assertThat(details.getStatus()).isEqualTo(ChecksStatus.COMPLETED);
@@ -117,10 +138,10 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
      */
     @Test
     public void shouldPublishStageDetails() {
-        PROPERTIES.setApplicable(true);
-        PROPERTIES.setSkipped(false);
-        PROPERTIES.setSuppressLogs(false);
-        PROPERTIES.setName("Test Status");
+        getProperties().setApplicable(true);
+        getProperties().setSkipped(false);
+        getProperties().setSuppressLogs(false);
+        getProperties().setName("Test Status");
         WorkflowJob job = createPipeline();
 
         job.setDefinition(new CpsFlowDefinition(""
@@ -143,7 +164,7 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
 
         buildWithResult(job, Result.FAILURE);
 
-        List<ChecksDetails> checksDetails = PUBLISHER_FACTORY.getPublishedChecks();
+        List<ChecksDetails> checksDetails = getFactory().getPublishedChecks();
 
         assertThat(checksDetails).hasSize(9);
 
@@ -232,10 +253,10 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
      */
     @Test
     public void shouldPublishStageDetailsWithoutLogsIfRequested() {
-        PROPERTIES.setApplicable(true);
-        PROPERTIES.setSkipped(false);
-        PROPERTIES.setName("Test Status");
-        PROPERTIES.setSuppressLogs(true);
+        getProperties().setApplicable(true);
+        getProperties().setSkipped(false);
+        getProperties().setName("Test Status");
+        getProperties().setSuppressLogs(true);
         WorkflowJob job = createPipeline();
 
         job.setDefinition(new CpsFlowDefinition(""
@@ -258,7 +279,7 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
 
         buildWithResult(job, Result.FAILURE);
 
-        List<ChecksDetails> checksDetails = PUBLISHER_FACTORY.getPublishedChecks();
+        List<ChecksDetails> checksDetails = getFactory().getPublishedChecks();
 
         assertThat(checksDetails).hasSize(9);
 
@@ -297,9 +318,9 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
      */
     @Test
     public void shouldPublishSimplePipeline() {
-        PROPERTIES.setApplicable(true);
-        PROPERTIES.setSkipped(false);
-        PROPERTIES.setName("Test Status");
+        getProperties().setApplicable(true);
+        getProperties().setSkipped(false);
+        getProperties().setName("Test Status");
         WorkflowJob job = createPipeline();
 
         job.setDefinition(new CpsFlowDefinition(""
@@ -309,7 +330,7 @@ public class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsP
 
         buildWithResult(job, Result.SUCCESS);
 
-        List<ChecksDetails> checksDetails = PUBLISHER_FACTORY.getPublishedChecks();
+        List<ChecksDetails> checksDetails = getFactory().getPublishedChecks();
 
         ChecksDetails details = checksDetails.get(1);
         assertThat(details.getOutput()).isPresent().get().satisfies(output -> assertThat(output.getTitle()).isPresent().get().isEqualTo("Success"));

--- a/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
@@ -50,14 +50,6 @@ class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest 
         getFactory().getPublishedChecks().clear();
     }
 
-    /**
-     * Provide inject an implementation of {@link AbstractStatusChecksProperties} to control the checks.
-     */
-    @TestExtension
-    public static class ChecksPropertiesTestExtension extends ChecksProperties {
-        // activate test extension
-    }
-
     private ChecksProperties getProperties() {
         return getJenkins().getInstance().getExtensionList(ChecksProperties.class)
                 .stream()
@@ -333,6 +325,14 @@ class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest 
      */
     @TestExtension
     public static class CapturingChecksPublisherTestExtension extends CapturingChecksPublisher.Factory {
+        // activate test extension
+    }
+
+    /**
+     * Provide inject an implementation of {@link AbstractStatusChecksProperties} to control the checks.
+     */
+    @TestExtension
+    public static class ChecksPropertiesTestExtension extends ChecksProperties {
         // activate test extension
     }
 

--- a/src/test/java/io/jenkins/plugins/checks/steps/PublishChecksStepITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/steps/PublishChecksStepITest.java
@@ -23,14 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class PublishChecksStepITest extends IntegrationTestWithJenkinsPerTest {
 
-    /**
-     * Provide a {@link CapturingChecksPublisher} to check published checks on each test.
-     */
-    @TestExtension
-    public static class CapturingChecksPublisherTestExtension extends CapturingChecksPublisher.Factory {
-        // activate test extension
-    }
-
     private CapturingChecksPublisher.Factory getFactory() {
         return getJenkins().getInstance().getExtensionList(ChecksPublisherFactory.class)
                 .stream()
@@ -95,5 +87,13 @@ class PublishChecksStepITest extends IntegrationTestWithJenkinsPerTest {
                         .withTitle("integration test")
                         .withRawDetails("raw details")
                         .build());
+    }
+
+    /**
+     * Provide a {@link CapturingChecksPublisher} to check published checks on each test.
+     */
+    @TestExtension
+    public static class CapturingChecksPublisherTestExtension extends CapturingChecksPublisher.Factory {
+        // activate test extension
     }
 }

--- a/src/test/java/io/jenkins/plugins/checks/steps/WithChecksStepITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/steps/WithChecksStepITest.java
@@ -4,15 +4,17 @@ import hudson.model.Result;
 import hudson.model.Run;
 import io.jenkins.plugins.checks.api.ChecksConclusion;
 import io.jenkins.plugins.checks.api.ChecksDetails;
+import io.jenkins.plugins.checks.api.ChecksPublisherFactory;
 import io.jenkins.plugins.checks.api.ChecksStatus;
 import io.jenkins.plugins.checks.util.CapturingChecksPublisher;
+import io.jenkins.plugins.checks.util.CapturingChecksPublisher.Factory;
 import io.jenkins.plugins.util.IntegrationTestWithJenkinsPerTest;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.steps.*;
 import org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -27,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests the "withChecks" step.
  */
-public class WithChecksStepITest extends IntegrationTestWithJenkinsPerTest {
+class WithChecksStepITest extends IntegrationTestWithJenkinsPerTest {
 
     /**
      * Tests that the step can inject the {@link ChecksInfo} into the closure.
@@ -44,14 +46,25 @@ public class WithChecksStepITest extends IntegrationTestWithJenkinsPerTest {
      * Provide a {@link CapturingChecksPublisher} to check published checks on each test.
      */
     @TestExtension
-    public static final CapturingChecksPublisher.Factory PUBLISHER_FACTORY = new CapturingChecksPublisher.Factory();
+    public static class CapturingChecksPublisherTestExtension extends CapturingChecksPublisher.Factory {
+        // activate test extension
+    }
+
+    private CapturingChecksPublisher.Factory getFactory() {
+        return getJenkins().getInstance().getExtensionList(ChecksPublisherFactory.class)
+                .stream()
+                .filter(f -> f instanceof Factory)
+                .map(f -> (Factory) f)
+                .findAny()
+                .orElseThrow(() -> new AssertionError("No CapturingChecksPublisher registered as @TestExtension?"));
+    }
 
     /**
-     * Clear captured checks on the {@link WithChecksStepITest#PUBLISHER_FACTORY} after each test.
+     * Clear captured checks on the {@link CapturingChecksPublisher.Factory} after each test.
      */
-    @After
+    @AfterEach
     public void clearPublisher() {
-        PUBLISHER_FACTORY.getPublishedChecks().clear();
+        getFactory().getPublishedChecks().clear();
     }
 
     /**
@@ -64,9 +77,9 @@ public class WithChecksStepITest extends IntegrationTestWithJenkinsPerTest {
 
         buildSuccessfully(job);
 
-        assertThat(PUBLISHER_FACTORY.getPublishedChecks().size()).isEqualTo(2);
-        ChecksDetails autoChecks = PUBLISHER_FACTORY.getPublishedChecks().get(0);
-        ChecksDetails manualChecks = PUBLISHER_FACTORY.getPublishedChecks().get(1);
+        assertThat(getFactory().getPublishedChecks().size()).isEqualTo(2);
+        ChecksDetails autoChecks = getFactory().getPublishedChecks().get(0);
+        ChecksDetails manualChecks = getFactory().getPublishedChecks().get(1);
 
         assertThat(autoChecks.getName()).isPresent().get().isEqualTo("test injection");
         assertThat(autoChecks.getStatus()).isEqualTo(ChecksStatus.IN_PROGRESS);
@@ -87,9 +100,9 @@ public class WithChecksStepITest extends IntegrationTestWithJenkinsPerTest {
 
         buildSuccessfully(job);
 
-        assertThat(PUBLISHER_FACTORY.getPublishedChecks().size()).isEqualTo(2);
-        ChecksDetails autoChecks = PUBLISHER_FACTORY.getPublishedChecks().get(0);
-        ChecksDetails manualChecks = PUBLISHER_FACTORY.getPublishedChecks().get(1);
+        assertThat(getFactory().getPublishedChecks().size()).isEqualTo(2);
+        ChecksDetails autoChecks = getFactory().getPublishedChecks().get(0);
+        ChecksDetails manualChecks = getFactory().getPublishedChecks().get(1);
 
         assertThat(autoChecks.getName()).isPresent().get().isEqualTo("test injection");
         assertThat(autoChecks.getStatus()).isEqualTo(ChecksStatus.IN_PROGRESS);
@@ -110,8 +123,8 @@ public class WithChecksStepITest extends IntegrationTestWithJenkinsPerTest {
 
         buildWithResult(job, Result.FAILURE);
 
-        assertThat(PUBLISHER_FACTORY.getPublishedChecks().size()).isEqualTo(2);
-        ChecksDetails failure = PUBLISHER_FACTORY.getPublishedChecks().get(1);
+        assertThat(getFactory().getPublishedChecks().size()).isEqualTo(2);
+        ChecksDetails failure = getFactory().getPublishedChecks().get(1);
 
         assertThat(failure.getStatus()).isEqualTo(ChecksStatus.COMPLETED);
         assertThat(failure.getConclusion()).isEqualTo(ChecksConclusion.FAILURE);
@@ -133,8 +146,8 @@ public class WithChecksStepITest extends IntegrationTestWithJenkinsPerTest {
 
         buildWithResult(job, Result.ABORTED);
 
-        assertThat(PUBLISHER_FACTORY.getPublishedChecks().size()).isEqualTo(2);
-        ChecksDetails abort = PUBLISHER_FACTORY.getPublishedChecks().get(1);
+        assertThat(getFactory().getPublishedChecks().size()).isEqualTo(2);
+        ChecksDetails abort = getFactory().getPublishedChecks().get(1);
 
         assertThat(abort.getStatus()).isEqualTo(ChecksStatus.COMPLETED);
         assertThat(abort.getConclusion()).isEqualTo(ChecksConclusion.CANCELED);

--- a/src/test/java/io/jenkins/plugins/checks/steps/WithChecksStepITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/steps/WithChecksStepITest.java
@@ -42,14 +42,6 @@ class WithChecksStepITest extends IntegrationTestWithJenkinsPerTest {
         buildSuccessfully(job);
     }
 
-    /**
-     * Provide a {@link CapturingChecksPublisher} to check published checks on each test.
-     */
-    @TestExtension
-    public static class CapturingChecksPublisherTestExtension extends CapturingChecksPublisher.Factory {
-        // activate test extension
-    }
-
     private CapturingChecksPublisher.Factory getFactory() {
         return getJenkins().getInstance().getExtensionList(ChecksPublisherFactory.class)
                 .stream()
@@ -226,5 +218,13 @@ class WithChecksStepITest extends IntegrationTestWithJenkinsPerTest {
                 return null;
             }
         }
+    }
+
+    /**
+     * Provide a {@link CapturingChecksPublisher} to check published checks on each test.
+     */
+    @TestExtension
+    public static class CapturingChecksPublisherTestExtension extends CapturingChecksPublisher.Factory {
+        // activate test extension
     }
 }


### PR DESCRIPTION
Adapting to https://github.com/jenkinsci/plugin-util-api-plugin/pull/161. The motivation for this is getting `jenkinsci/bom` up and running with JENKINS-45047, which exposes this compatibility problem.

Monkey see, monkey do style programming (copying `warnings-ng`), so please don't be too hard on me. I have no idea what I am doing here, just banging around on a keyboard until the tests pass. If something doesn't make sense to you, there is probably a better way. One thing I am confident about is that each and every change in this PR is necessary to get the tests to pass, so if you think some change isn't necessary, try testing without it and see what happens.

CC @timja @uhafner