### PR TITLE
Only analyze classes from `checks-api` plugin

### DIFF
--- a/src/test/java/io/jenkins/plugins/checks/ArchitectureTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/ArchitectureTest.java
@@ -14,7 +14,7 @@ import org.junit.runner.RunWith;
  * @author Ullrich Hafner
  */
 @SuppressWarnings("hideutilityclassconstructor")
-@AnalyzeClasses(packages = "io.jenkins.plugins..")
+@AnalyzeClasses(packages = "io.jenkins.plugins.checks..")
 class ArchitectureTest {
     @ArchTest
     static final ArchRule NO_JENKINS_INSTANCE_CALL = PluginArchitectureRules.NO_JENKINS_INSTANCE_CALL;


### PR DESCRIPTION
Consistent with https://github.com/jenkinsci/checks-api-plugin/blob/1a45e19783b3aa219d65bf0ece0364d06db6b160/src/test/java/io/jenkins/plugins/checks/PackageArchitectureTest.java#L20. Discovered in https://github.com/jenkinsci/bom/pull/1385#issuecomment-1211020782.

CC @uhafner 