### PR TITLE
Bump version of analysis-pom to 5.35.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,6 @@
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 
-    <!-- Jenkins Plug-in Dependencies Versions -->
-    <plugin-util-api.version>2.17.0</plugin-util-api.version>
     <testcontainers.version>1.17.5</testcontainers.version>
   </properties>
 
@@ -46,14 +44,12 @@
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
-      <version>${plugin-util-api.version}</version>
     </dependency>
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>plugin-util-api</artifactId>
-      <version>${plugin-util-api.version}</version>
+      <classifier>tests</classifier>
       <scope>test</scope>
-      <type>test-jar</type>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>5.33.0</version>
+    <version>5.35.0</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Also remove the version from `plugin-util-api` dependencies since this plugin is now part of the BOM.

Replaces:
- #192
- #190

Prerequisite for https://github.com/jenkinsci/bom/pull/1513