### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Implementations:
 * [GitHub Checks Plugin](https://plugins.jenkins.io/github-checks)
 * [Gitea Checks Plugin](https://plugins.jenkins.io/gitea-checks/)
 
-This plugin, along with it's [GitHub implementation](https://plugins.jenkins.io/github-checks), has been installed on [ci.jenkins.io](https://ci.jenkins.io/Plugins) to help maintain over 1500 Jenkins plugins. You can take a look at the [action](https://github.com/jenkinsci/checks-api-plugin/runs/1025532156) for this repository or other plugin repositories under [Jenkins organization](https://github.com/jenkinsci) for the results.
+This plugin, along with its [GitHub implementation](https://plugins.jenkins.io/github-checks), has been installed on [ci.jenkins.io](https://ci.jenkins.io/Plugins) to help maintain over 1500 Jenkins plugins. You can take a look at the [action](https://github.com/jenkinsci/checks-api-plugin/runs/1025532156) for this repository or other plugin repositories under [Jenkins organization](https://github.com/jenkinsci) for the results.
 
 ## Embedded Features
 
@@ -46,8 +46,8 @@ publishChecks name: 'example', title: 'Pipeline Check', summary: 'check through 
     actions: [[label:'an-user-request-action', description:'actions allow users to request pre-defined behaviours', identifier:'an unique identifier']]
 ```
 
-*To use customized actions, you will need to write a Jenkins plugin
-If you want to add GitHub checks actions which are basically buttons on the checks report,
+*To use customized actions, you will need to write a Jenkins plugin.
+If you want to add GitHub checks actions, which are basically buttons on the checks report,
 you need to extend [GHEventSubscriber](https://github.com/jenkinsci/github-plugin/blob/master/src/main/java/org/jenkinsci/plugins/github/extension/GHEventsSubscriber.java) to handle the event,
 see [the handler](https://github.com/jenkinsci/github-checks-plugin/blob/ea060be67dad522ab6c31444fc4274955ac6e918/src/main/java/io/jenkins/plugins/checks/github/CheckRunGHEventSubscriber.java) for re-run requests as an example.*
 


### PR DESCRIPTION
The README had a few typos.
1. Using the contraction form of `it's` rather than the possessive `its`.
1. A period missing before a capital. (I assume they should be two separate sentences.)
1. `which are basically buttons on the checks report` is a non-essential clause, so I added a comma to the beginning.

--------
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
