### PR TITLE
Only return names in getStageOrBranchName if it's a stage or branch

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
@@ -26,6 +26,7 @@ import org.jenkinsci.plugins.workflow.actions.LogAction;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.actions.WarningAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graph.StepNode;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -53,9 +54,14 @@ class FlowExecutionAnalyzer {
     }
 
     private static Optional<String> getStageOrBranchName(final FlowNode node) {
-        return getParallelName(node)
-                .map(Optional::of)
-                .orElse(getStageName(node));
+        if (node instanceof BlockStartNode) {
+            // a stage or parallel branch must be a BlockStartNode
+            return getParallelName(node).or(() -> getStageName(node));
+        }
+        else {
+            // otherwise, this is a regular step, don't return a name
+            return Optional.empty();
+        }
     }
 
     private static Optional<String> getStageName(final FlowNode node) {


### PR DESCRIPTION
If `stageOrBranchName` is present, we skip processing errors. This is on the assumption that if `stageOrBranchName` is present it is a stage or branch. However, normal steps like `sh` can have labels too and was returned as the `stageOrBranchName`. This causes labeled steps to not have their errors processed.

We fix this by returning empty in `getStageOrBranchName` if the node is not a `BlockStartNode`.

This fixes https://github.com/jenkinsci/checks-api-plugin/issues/252

### Testing done

I've tested this on a private Jenkins instance. As far as I can tell, it works as expected. This has no pre-existing tests and I'm honestly not sure how to write them.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue