### PR TITLE
Change default behavior to truncate Checks text from start when maxSize present

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/api/ChecksOutput.java
+++ b/src/main/java/io/jenkins/plugins/checks/api/ChecksOutput.java
@@ -76,7 +76,13 @@ public class ChecksOutput {
      * @return Text, truncated to maxSize with truncation message if appropriate.
      */
     public Optional<String> getText(final int maxSize) {
-        return Optional.ofNullable(text).map(s -> s.build(maxSize));
+        return Optional.ofNullable(text)
+                .map(s -> new TruncatedString.Builder()
+                        .setChunkOnNewlines()
+                        .setTruncateStart()
+                        .addText(s.toString())
+                        .build()
+                        .buildByChars(maxSize));
     }
 
     public List<ChecksAnnotation> getChecksAnnotations() {

--- a/src/test/java/io/jenkins/plugins/checks/api/ChecksOutputTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/api/ChecksOutputTest.java
@@ -97,6 +97,35 @@ class ChecksOutputTest {
                 .containsExactlyInAnyOrderElementsOf(images);
     }
 
+    @Test
+    void shouldTruncateTestFromStart() {
+        String longText = "This is the beginning.\n" + "Middle part.\n".repeat(10) + "This is the end.\n";
+        ChecksOutput checksOutput = new ChecksOutputBuilder()
+                .withText(longText)
+                .build();
+
+        String truncated = checksOutput.getText(75).orElse("");
+        
+        assertThat(truncated)
+                .startsWith("Output truncated.")
+                .endsWith("This is the end.\n");
+        assertThat(truncated.length()).isLessThanOrEqualTo(75);
+    }
+
+    @Test
+    void shouldNotTruncateShortText() {
+        String shortText = "This is a short text that should not be truncated.";
+        ChecksOutput checksOutput = new ChecksOutputBuilder()
+                .withText(shortText)
+                .build();
+
+        String result = checksOutput.getText(100).orElse("");
+        
+        assertThat(result)
+                .isEqualTo(shortText)
+                .doesNotContain("Output truncated.");
+    }
+
     private List<ChecksAnnotation> createAnnotations() {
         final ChecksAnnotationBuilder builder = new ChecksAnnotationBuilder()
                 .withPath("src/main/java/1.java")

--- a/src/test/java/io/jenkins/plugins/checks/api/ChecksOutputTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/api/ChecksOutputTest.java
@@ -98,7 +98,7 @@ class ChecksOutputTest {
     }
 
     @Test
-    void shouldTruncateTestFromStart() {
+    void shouldTruncateTextFromStart() {
         String longText = "This is the beginning.\n" + "Middle part.\n".repeat(10) + "This is the end.\n";
         ChecksOutput checksOutput = new ChecksOutputBuilder()
                 .withText(longText)


### PR DESCRIPTION
From these two tickets: 

https://github.com/jenkinsci/github-checks-plugin/issues/343#issuecomment-2628826962
https://github.com/jenkinsci/github-checks-plugin/issues/423

We believe it is better to default truncating the checks text default behavior to be from the start rather than the end of the logs. This behavior is better because typically the most relevant logs, especially error logs, happen at the end of the output.

### Testing done

Added two unit tests to cover the change, ensured that the unit tests passed
<img width="627" alt="Screenshot 2025-02-04 at 3 51 34 PM" src="https://github.com/user-attachments/assets/5a9ddf15-69a7-4b40-880b-a4487c43fb1f" />


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
