### PR TITLE
Add link to logs for failed pipeline step

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.collections.iterators.ReverseListIterator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.jenkinsci.plugins.workflow.actions.ArgumentsAction;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
@@ -146,6 +147,14 @@ class FlowExecutionAnalyzer {
         else {
             nodeTextBuilder.append(String.format("**Unstable**: *%s*", warningAction.getMessage()));
             nodeSummaryBuilder.append(String.format("```%n%s%n```", warningAction.getMessage()));
+        }
+        try {
+            String logsUrl = String.format("%s%slog", DisplayURLProvider.get().getRoot(), flowNode.getUrl());
+            nodeTextBuilder.append(String.format(" - [logs](%s)", logsUrl));
+        }
+        catch (IOException e) {
+            LOGGER.log(Level.WARNING, String.format("Failed to get log url for step '%s'",
+                    flowNode.getDisplayName()).replaceAll("[\r\n]", ""), e);
         }
         nodeTextBuilder.append("\n");
         nodeSummaryBuilder.append("\n\n");  // Ensure a double newline at the end of summary so the subsequence heading works

--- a/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
@@ -196,7 +196,7 @@ class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest 
                     + "  \\* In parallel \\*\\(running\\)\\*\\s+"
                     + "    \\* p1 \\*\\(running\\)\\*\\s+"
                     + "      \\* p1s1 \\*\\([^)]+\\)\\*\\s+"
-                    + "        \\*\\*Unstable\\*\\*: \\*something went wrong\\*\\s+"
+                    + "        \\*\\*Unstable\\*\\*: \\*something went wrong\\* - \\[logs\\]\\([^)]+\\)\\s+"
                     + "      \\* p1s2 \\*\\(running\\)\\*\\s+"
                     + "    \\* p2 \\*\\([^)]+\\)\\*\\s+.*", Pattern.DOTALL));
         });
@@ -223,7 +223,7 @@ class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest 
                             + "  \\* In parallel \\*\\([^)]+\\)\\*\\s+"
                             + "    \\* p1 \\*\\([^)]+\\)\\*\\s+"
                             + "      \\* p1s1 \\*\\([^)]+\\)\\*\\s+"
-                            + "        \\*\\*Unstable\\*\\*: \\*something went wrong\\*\\s+"
+                            + "        \\*\\*Unstable\\*\\*: \\*something went wrong\\* - \\[logs\\]\\([^)]+\\)\\s+"
                             + "      \\* p1s2 \\*\\([^)]+\\)\\*\\s+"
                             + "    \\* p2 \\*\\([^)]+\\)\\*\\s+"
                             + "  \\* Fails \\*\\([^)]+\\)\\*\\s+"
@@ -288,11 +288,11 @@ class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest 
                             + "  \\* In parallel \\*\\([^)]+\\)\\*\\s+"
                             + "    \\* p1 \\*\\([^)]+\\)\\*\\s+"
                             + "      \\* p1s1 \\*\\([^)]+\\)\\*\\s+"
-                            + "        \\*\\*Unstable\\*\\*: \\*something went wrong\\*\\s+"
+                            + "        \\*\\*Unstable\\*\\*: \\*something went wrong\\* - \\[logs\\]\\([^)]+\\)\\s+"
                             + "      \\* p1s2 \\*\\([^)]+\\)\\*\\s+"
                             + "    \\* p2 \\*\\([^)]+\\)\\*\\s+"
                             + "  \\* Fails \\*\\([^)]+\\)\\*\\s+"
-                            + "    \\*\\*Error\\*\\*: \\*No artifacts found that match the file pattern \"oh dear\". Configuration error\\?\\*\\s+.*",
+                            + "    \\*\\*Error\\*\\*: \\*No artifacts found that match the file pattern \"oh dear\". Configuration error\\?\\* - \\[logs\\]\\([^)]+\\)\\s+.*",
                     Pattern.DOTALL));
         });
     }


### PR DESCRIPTION
Adds a link to the pipeline steps log in the check details. The logs embedded in the summary can be truncated. In the case of multiple steps failing, entire step logs can be truncated. Having the link be in the details (the step tree) means it's less likely to be truncated and the full logs can be easily viewed without having to dig through the steps list on Jenkins.

### Testing done

I've tested on our local Jenkins instance and updated the tests. 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue