### PR TITLE
Support verbose console logs for freestyle jobs

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/status/AbstractBuildAnalyzer.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/AbstractBuildAnalyzer.java
@@ -1,0 +1,86 @@
+package io.jenkins.plugins.checks.status;
+
+import java.util.logging.Logger;
+
+import hudson.model.Result;
+import hudson.model.Run;
+import io.jenkins.plugins.checks.api.ChecksOutput;
+
+/**
+ * Base class for build analyzers that extract output from Jenkins builds.
+ */
+abstract class AbstractBuildAnalyzer {
+    protected static final Logger LOGGER = Logger.getLogger(AbstractBuildAnalyzer.class.getName());
+    protected static final String TRUNCATED_MESSAGE = "\n\nOutput truncated.";
+    protected static final String TRUNCATED_MESSAGE_BUILD_LOG = "Build log truncated.\n\n";
+    protected static final int MAX_MESSAGE_SIZE_TO_CHECKS_API = 65_535;
+    protected static final String LOG_DETAILS_TEMPLATE = "<details><summary>Build Log</summary>%n%n```%n%s%n```%n%n</details>";
+
+    private final Run<?, ?> run;
+    private final boolean suppressLogs;
+
+    protected AbstractBuildAnalyzer(final Run<?, ?> run, final boolean suppressLogs) {
+        this.run = run;
+        this.suppressLogs = suppressLogs;
+    }
+
+    /**
+     * Gets the run associated with this analyzer.
+     *
+     * @return the run
+     */
+    protected Run<?, ?> getRun() {
+        return run;
+    }
+
+    /**
+     * Checks if logs should be suppressed.
+     *
+     * @return true if logs should be suppressed
+     */
+    protected boolean isSuppressLogs() {
+        return suppressLogs;
+    }
+
+    /**
+     * Extracts output from the build.
+     *
+     * @return the extracted output
+     */
+    public abstract ChecksOutput extractOutput();
+
+    /**
+     * Extract the output title based on the build result.
+     *
+     * @param title
+     *         custom title to use if the build failed
+     * @return the output title
+     */
+    protected String extractOutputTitle(final String title) {
+        Result result = getRun().getResult();
+        if (result == null) {
+            return "In progress";
+        }
+        if (result.isBetterOrEqualTo(Result.SUCCESS)) {
+            return "Success";
+        }
+
+        if (title != null) {
+            return title;
+        }
+
+        if (result.isBetterOrEqualTo(Result.UNSTABLE)) {
+            return "Unstable";
+        }
+        if (result.isBetterOrEqualTo(Result.FAILURE)) {
+            return "Failure";
+        }
+        if (result.isBetterOrEqualTo(Result.NOT_BUILT)) {
+            return "Skipped";
+        }
+        if (result.isBetterOrEqualTo(Result.ABORTED)) {
+            return "Aborted";
+        }
+        throw new IllegalStateException("Unsupported run result: " + result);
+    }
+} 

--- a/src/main/java/io/jenkins/plugins/checks/status/AbstractBuildAnalyzer.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/AbstractBuildAnalyzer.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.checks.status;
 
+import java.util.Optional;
 import java.util.logging.Logger;
 
 import hudson.model.Result;
@@ -56,7 +57,7 @@ abstract class AbstractBuildAnalyzer {
      *         custom title to use if the build failed
      * @return the output title
      */
-    protected String extractOutputTitle(final String title) {
+    protected String extractOutputTitle(final Optional<String> title) {
         Result result = getRun().getResult();
         if (result == null) {
             return "In progress";
@@ -65,8 +66,8 @@ abstract class AbstractBuildAnalyzer {
             return "Success";
         }
 
-        if (title != null) {
-            return title;
+        if (title.isPresent()) {
+            return title.get();
         }
 
         if (result.isBetterOrEqualTo(Result.UNSTABLE)) {

--- a/src/main/java/io/jenkins/plugins/checks/status/AbstractRunAnalyzer.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/AbstractRunAnalyzer.java
@@ -10,8 +10,8 @@ import io.jenkins.plugins.checks.api.ChecksOutput;
 /**
  * Base class for build analyzers that extract output from Jenkins builds.
  */
-abstract class AbstractBuildAnalyzer {
-    protected static final Logger LOGGER = Logger.getLogger(AbstractBuildAnalyzer.class.getName());
+abstract class AbstractRunAnalyzer {
+    protected static final Logger LOGGER = Logger.getLogger(AbstractRunAnalyzer.class.getName());
     protected static final String TRUNCATED_MESSAGE = "\n\nOutput truncated.";
     protected static final String TRUNCATED_MESSAGE_BUILD_LOG = "Build log truncated.\n\n";
     protected static final int MAX_MESSAGE_SIZE_TO_CHECKS_API = 65_535;
@@ -20,7 +20,7 @@ abstract class AbstractBuildAnalyzer {
     private final Run<?, ?> run;
     private final boolean suppressLogs;
 
-    protected AbstractBuildAnalyzer(final Run<?, ?> run, final boolean suppressLogs) {
+    protected AbstractRunAnalyzer(final Run<?, ?> run, final boolean suppressLogs) {
         this.run = run;
         this.suppressLogs = suppressLogs;
     }

--- a/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
@@ -18,6 +18,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Computer;
+import hudson.model.FreeStyleBuild;
 import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.Result;
@@ -101,6 +102,10 @@ public final class BuildStatusChecksPublisher {
 
     @CheckForNull
     static ChecksOutput getOutput(final Run<?, ?> run) {
+        if (run instanceof FreeStyleBuild) {
+            return getFreeStyleBuildOutput(run);
+        }
+
         if (!(run instanceof FlowExecutionOwner.Executable)) {
             return null;
         }
@@ -117,6 +122,10 @@ public final class BuildStatusChecksPublisher {
 
     static ChecksOutput getOutput(final Run<?, ?> run, final FlowExecution execution) {
         return new FlowExecutionAnalyzer(run, execution, findProperties(run.getParent()).isSuppressLogs(run.getParent())).extractOutput();
+    }
+
+    static ChecksOutput getFreeStyleBuildOutput(final Run<?, ?> run) {
+        return new FreeStyleBuildAnalyzer(run, findProperties(run.getParent()).isSuppressLogs(run.getParent())).extractOutput();
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
@@ -32,7 +32,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable;
 
 @SuppressWarnings("PMD.GodClass")
-class FlowExecutionAnalyzer extends AbstractBuildAnalyzer {
+class FlowExecutionAnalyzer extends AbstractRunAnalyzer {
     private final FlowExecution execution;
     private final Stack<Integer> indentationStack = new Stack<>(); // NOPMD TODO: replace with DeQueue
 

--- a/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
@@ -186,7 +186,7 @@ class FlowExecutionAnalyzer extends AbstractBuildAnalyzer {
         }
 
         return new ChecksOutput.ChecksOutputBuilder()
-                .withTitle(extractOutputTitle(title))
+                .withTitle(extractOutputTitle(Optional.ofNullable(title)))
                 .withSummary(summaryBuilder.build())
                 .withText(textBuilder.build())
                 .build();
@@ -230,14 +230,5 @@ class FlowExecutionAnalyzer extends AbstractBuildAnalyzer {
                     flowNode.getDisplayName()).replaceAll("[\r\n]", ""), e);
             return null;
         }
-    }
-
-    @Override
-    protected String extractOutputTitle(final String customTitle) {
-        if (getRun().getResult() == Result.FAILURE && StringUtils.isNotBlank(customTitle)) {
-            return customTitle;
-        }
-
-        return super.extractOutputTitle(customTitle);
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
@@ -4,7 +4,6 @@ import static io.jenkins.plugins.checks.utils.FlowNodeUtils.getEnclosingBlockNam
 import static io.jenkins.plugins.checks.utils.FlowNodeUtils.getEnclosingStagesAndParallels;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import hudson.model.Result;
 import hudson.model.Run;
 import io.jenkins.plugins.checks.api.ChecksOutput;
 import io.jenkins.plugins.checks.api.TruncatedString;

--- a/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/FlowExecutionAnalyzer.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Stack;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.iterators.ReverseListIterator;
 import org.apache.commons.lang3.StringUtils;
@@ -34,21 +33,13 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.support.visualization.table.FlowGraphTable;
 
 @SuppressWarnings("PMD.GodClass")
-class FlowExecutionAnalyzer {
-    private static final Logger LOGGER = Logger.getLogger(FlowExecutionAnalyzer.class.getName());
-    private static final String TRUNCATED_MESSAGE = "\n\nOutput truncated.";
-    private static final String TRUNCATED_MESSAGE_BUILD_LOG = "Build log truncated.\n\n";
-    private static final int MAX_MESSAGE_SIZE_TO_CHECKS_API = 65_535;
-
-    private final Run<?, ?> run;
+class FlowExecutionAnalyzer extends AbstractBuildAnalyzer {
     private final FlowExecution execution;
     private final Stack<Integer> indentationStack = new Stack<>(); // NOPMD TODO: replace with DeQueue
-    private final boolean suppressLogs;
 
     FlowExecutionAnalyzer(final Run<?, ?> run, final FlowExecution execution, final boolean suppressLogs) {
-        this.run = run;
+        super(run, suppressLogs);
         this.execution = execution;
-        this.suppressLogs = suppressLogs;
     }
 
     private static Optional<String> getStageOrBranchName(final FlowNode node) {
@@ -134,7 +125,7 @@ class FlowExecutionAnalyzer {
             var displayName = errorAction == null ? "[no error action]" : errorAction.getDisplayName();
             nodeTextBuilder.append(String.format("**Error**: *%s*", displayName));
             nodeSummaryBuilder.append(String.format("```%n%s%n```%n", displayName));
-            if (!suppressLogs) {
+            if (!isSuppressLogs()) {
                 // -2 for "\n\n" at the end of the summary and -30 for buffer
                 String logTemplate = "<details>%n<summary>Build log</summary>%n%n```%n%s%n```%n</details>";
                 int maxMessageSize = MAX_MESSAGE_SIZE_TO_CHECKS_API - nodeSummaryBuilder.length() - logTemplate.length() - 32;
@@ -161,7 +152,8 @@ class FlowExecutionAnalyzer {
         return Pair.of(nodeTextBuilder.toString(), nodeSummaryBuilder.toString());
     }
 
-    ChecksOutput extractOutput() {
+    @Override
+    public ChecksOutput extractOutput() {
         FlowGraphTable table = new FlowGraphTable(execution);
         table.build();
 
@@ -240,31 +232,12 @@ class FlowExecutionAnalyzer {
         }
     }
 
-    private String extractOutputTitle(final String title) {
-        Result result = run.getResult();
-        if (result == null) {
-            return "In progress";
-        }
-        if (result.isBetterOrEqualTo(Result.SUCCESS)) {
-            return "Success";
+    @Override
+    protected String extractOutputTitle(final String customTitle) {
+        if (getRun().getResult() == Result.FAILURE && StringUtils.isNotBlank(customTitle)) {
+            return customTitle;
         }
 
-        if (title != null) {
-            return title;
-        }
-
-        if (result.isBetterOrEqualTo(Result.UNSTABLE)) {
-            return "Unstable";
-        }
-        if (result.isBetterOrEqualTo(Result.FAILURE)) {
-            return "Failure";
-        }
-        if (result.isBetterOrEqualTo(Result.NOT_BUILT)) {
-            return "Skipped";
-        }
-        if (result.isBetterOrEqualTo(Result.ABORTED)) {
-            return "Aborted";
-        }
-        throw new IllegalStateException("Unsupported run result: " + result);
+        return super.extractOutputTitle(customTitle);
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/status/FreeStyleBuildAnalyzer.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/FreeStyleBuildAnalyzer.java
@@ -4,13 +4,15 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.logging.Level;
 
+import org.apache.commons.lang3.StringUtils;
+
 import hudson.model.Run;
 import io.jenkins.plugins.checks.api.ChecksOutput;
 import io.jenkins.plugins.checks.api.TruncatedString;
 
-import org.apache.commons.lang3.StringUtils;
-
 class FreeStyleBuildAnalyzer extends AbstractRunAnalyzer {
+    private static final int MAX_LOG_LINES = 1000;
+
     FreeStyleBuildAnalyzer(final Run<?, ?> run, final boolean suppressLogs) {
         super(run, suppressLogs);
     }
@@ -27,24 +29,33 @@ class FreeStyleBuildAnalyzer extends AbstractRunAnalyzer {
         }
 
         TruncatedString.Builder summaryBuilder = new TruncatedString.Builder()
-                .withTruncationText(TRUNCATED_MESSAGE);
+                .withTruncationText(TRUNCATED_MESSAGE_BUILD_LOG);
 
         String log;
         try {
             // Get all log lines
-            java.util.List<String> allLines = getRun().getLog(Integer.MAX_VALUE);
+            java.util.List<String> allLines = getRun().getLog(MAX_LOG_LINES + 1);
+            boolean truncatedLines = allLines.size() > MAX_LOG_LINES;
             int maxMessageSize = MAX_MESSAGE_SIZE_TO_CHECKS_API - LOG_DETAILS_TEMPLATE.length() - 32;
+            
+            if (truncatedLines) {
+                allLines = allLines.subList(1, MAX_LOG_LINES + 1);
+            }
             
             log = String.join("\n", allLines);
             log = log.replaceAll("\u001B\\[[;\\d]*m", "");
 
-            log = new TruncatedString.Builder()
+            TruncatedString.Builder logBuilder = new TruncatedString.Builder()
                     .setChunkOnNewlines()
                     .setTruncateStart()
                     .withTruncationText(TRUNCATED_MESSAGE_BUILD_LOG)
-                    .addText(log)
-                    .build()
-                    .build(maxMessageSize);
+                    .addText(log);
+            
+            if (truncatedLines) {
+                logBuilder.setForceTruncationText();
+            }
+
+            log = logBuilder.build().build(maxMessageSize);
 
             if (StringUtils.isNotBlank(log)) {
                 summaryBuilder.addText(String.format(LOG_DETAILS_TEMPLATE, log));

--- a/src/main/java/io/jenkins/plugins/checks/status/FreeStyleBuildAnalyzer.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/FreeStyleBuildAnalyzer.java
@@ -1,0 +1,58 @@
+package io.jenkins.plugins.checks.status;
+
+import java.io.IOException;
+import java.util.logging.Level;
+
+import hudson.model.Run;
+import io.jenkins.plugins.checks.api.ChecksOutput;
+import io.jenkins.plugins.checks.api.TruncatedString;
+import org.apache.commons.lang3.StringUtils;
+
+class FreeStyleBuildAnalyzer extends AbstractBuildAnalyzer {
+    FreeStyleBuildAnalyzer(final Run<?, ?> run, final boolean suppressLogs) {
+        super(run, suppressLogs);
+    }
+
+    @Override
+    public ChecksOutput extractOutput() {
+        String title = extractOutputTitle(null);
+
+        ChecksOutput.ChecksOutputBuilder output = new ChecksOutput.ChecksOutputBuilder()
+                .withTitle(title);
+
+        if (isSuppressLogs()) {
+            return output.build();
+        }
+
+        TruncatedString.Builder summaryBuilder = new TruncatedString.Builder()
+                .withTruncationText(TRUNCATED_MESSAGE);
+
+        String log;
+        try {
+            // Get all log lines
+            java.util.List<String> allLines = getRun().getLog(Integer.MAX_VALUE);
+            int maxMessageSize = MAX_MESSAGE_SIZE_TO_CHECKS_API - LOG_DETAILS_TEMPLATE.length() - 32;
+            
+            log = String.join("\n", allLines);
+            log = log.replaceAll("\u001B\\[[;\\d]*m", "");
+
+            log = new TruncatedString.Builder()
+                    .setChunkOnNewlines()
+                    .setTruncateStart()
+                    .withTruncationText(TRUNCATED_MESSAGE_BUILD_LOG)
+                    .addText(log)
+                    .build()
+                    .build(maxMessageSize);
+
+            if (StringUtils.isNotBlank(log)) {
+                summaryBuilder.addText(String.format(LOG_DETAILS_TEMPLATE, log));
+            }
+        }
+        catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to get build log for run: " + getRun(), e);
+            return output.build();
+        }
+
+        return output.withSummary(summaryBuilder.build()).build();
+    }
+} 

--- a/src/main/java/io/jenkins/plugins/checks/status/FreeStyleBuildAnalyzer.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/FreeStyleBuildAnalyzer.java
@@ -1,11 +1,13 @@
 package io.jenkins.plugins.checks.status;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.logging.Level;
 
 import hudson.model.Run;
 import io.jenkins.plugins.checks.api.ChecksOutput;
 import io.jenkins.plugins.checks.api.TruncatedString;
+
 import org.apache.commons.lang3.StringUtils;
 
 class FreeStyleBuildAnalyzer extends AbstractBuildAnalyzer {
@@ -15,7 +17,7 @@ class FreeStyleBuildAnalyzer extends AbstractBuildAnalyzer {
 
     @Override
     public ChecksOutput extractOutput() {
-        String title = extractOutputTitle(null);
+        String title = extractOutputTitle(Optional.empty());
 
         ChecksOutput.ChecksOutputBuilder output = new ChecksOutput.ChecksOutputBuilder()
                 .withTitle(title);
@@ -49,8 +51,9 @@ class FreeStyleBuildAnalyzer extends AbstractBuildAnalyzer {
             }
         }
         catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Failed to get build log for run: " + getRun(), e);
-            return output.build();
+            LOGGER.log(Level.WARNING, String.format("Failed to extract logs for step '%s'",
+                    getRun().getDisplayName()).replaceAll("[\r\n]", ""), e);
+            return null;
         }
 
         return output.withSummary(summaryBuilder.build()).build();

--- a/src/main/java/io/jenkins/plugins/checks/status/FreeStyleBuildAnalyzer.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/FreeStyleBuildAnalyzer.java
@@ -10,7 +10,7 @@ import io.jenkins.plugins.checks.api.TruncatedString;
 
 import org.apache.commons.lang3.StringUtils;
 
-class FreeStyleBuildAnalyzer extends AbstractBuildAnalyzer {
+class FreeStyleBuildAnalyzer extends AbstractRunAnalyzer {
     FreeStyleBuildAnalyzer(final Run<?, ?> run, final boolean suppressLogs) {
         super(run, suppressLogs);
     }

--- a/src/main/java/io/jenkins/plugins/checks/status/FreeStyleBuildAnalyzer.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/FreeStyleBuildAnalyzer.java
@@ -53,7 +53,7 @@ class FreeStyleBuildAnalyzer extends AbstractBuildAnalyzer {
         catch (IOException e) {
             LOGGER.log(Level.WARNING, String.format("Failed to extract logs for step '%s'",
                     getRun().getDisplayName()).replaceAll("[\r\n]", ""), e);
-            return null;
+            return output.build();
         }
 
         return output.withSummary(summaryBuilder.build()).build();

--- a/src/test/java/io/jenkins/plugins/checks/api/TruncatedStringTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/api/TruncatedStringTest.java
@@ -1,15 +1,15 @@
 package io.jenkins.plugins.checks.api;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Test behavior of the {@link TruncatedString}.
@@ -173,5 +173,16 @@ class TruncatedStringTest {
         assertThat(build(chunkOnChars, 20)).isEqualTo("xxxx\nx\n");
         builder.addText("xxxxxxxxxxxxxxx"); // 15
         assertThat(build(chunkOnChars, 20)).isEqualTo(chunkOnChars ? "xxxx\nx\nE_TOO_MUCH_☃" : "xxxx\nE_TOO_MUCH_☃");
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void shouldForceTruncationText(final boolean chunkOnNewlines, final boolean chunkOnChars) {
+        if (chunkOnNewlines) {
+            builder.setChunkOnNewlines();
+        }
+        builder.setForceTruncationText();
+        builder.addText("Hello\n");
+        assertThat(build(chunkOnChars, 20)).isEqualTo("Hello\nTruncated");
     }
 }

--- a/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.TestExtension;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import hudson.Functions;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Shell;
-import hudson.Functions;
 import io.jenkins.plugins.checks.api.ChecksConclusion;
 import io.jenkins.plugins.checks.api.ChecksDetails;
 import io.jenkins.plugins.checks.api.ChecksPublisherFactory;
@@ -420,7 +420,7 @@ class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest 
         getProperties().setName("FreeStyle Status");
 
         var project = createFreeStyleProject();
-        if (System.getProperty("os.name").toLowerCase(java.util.Locale.ROOT).contains("win")) {
+        if (Functions.isWindows()) {
             project.getBuildersList().add(new BatchFile("echo hello from windows"));
         }
         else {
@@ -454,7 +454,7 @@ class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest 
         for (int i = 0; i < logLines; i++) {
             script.append("echo line ").append(i).append(logSuffix);
         }
-        if (System.getProperty("os.name").toLowerCase(java.util.Locale.ROOT).contains("win")) {
+        if (Functions.isWindows()) {
             project.getBuildersList().add(new BatchFile(script.toString()));
         }
         else {

--- a/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
@@ -454,7 +454,7 @@ class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest 
             script.append("echo line ").append(i).append(logSuffix);
         }
         if (System.getProperty("os.name").toLowerCase(java.util.Locale.ROOT).contains("win")) {
-            project.getBuildersList().add(new BatchFile(script.toString().replace("\n", " && ")));
+            project.getBuildersList().add(new BatchFile(script.toString()));
         }
         else {
             project.getBuildersList().add(new Shell(script.toString()));

--- a/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
@@ -17,6 +17,7 @@ import hudson.model.Result;
 import hudson.model.Run;
 import hudson.tasks.BatchFile;
 import hudson.tasks.Shell;
+import hudson.Functions;
 import io.jenkins.plugins.checks.api.ChecksConclusion;
 import io.jenkins.plugins.checks.api.ChecksDetails;
 import io.jenkins.plugins.checks.api.ChecksPublisherFactory;
@@ -386,7 +387,7 @@ class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest 
 
         // Create a FreeStyle project and add a build step
         var project = createFreeStyleProject();
-        if (System.getProperty("os.name").toLowerCase(java.util.Locale.ROOT).contains("win")) {
+        if (Functions.isWindows()) {
             project.getBuildersList().add(new BatchFile("echo hello from windows"));
         }
         else {

--- a/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.checks.status;
 
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,6 +10,9 @@ import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.jvnet.hudson.test.TestExtension;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -436,29 +440,32 @@ class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest 
         });
     }
 
+    @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "Called by JUnit")
+    private static Stream<Arguments> freeStyleBuildLogParameters() {
+        return Stream.of(
+                Arguments.of(characterTruncationLog()),  // Truncate by lines
+                Arguments.of(lineTruncationLog())  // Truncate by character length
+        );
+    }
+
     /**
-     * Tests that FreeStyleBuildAnalyzer truncates large logs.
+     * Tests that FreeStyleBuildAnalyzer truncates logs based on the number of lines or character length.
+     * @param log the log content to be tested for truncation
      */
-    @Test
-    public void shouldTruncateFreeStyleBuildLog() throws Exception {
+    @ParameterizedTest
+    @MethodSource("freeStyleBuildLogParameters")
+    public void shouldTruncateFreeStyleBuildLog(final String log) throws Exception {
         getProperties().setApplicable(true);
         getProperties().setSkipped(false);
         getProperties().setSuppressLogs(false);
         getProperties().setName("FreeStyle Status");
 
         var project = createFreeStyleProject();
-        int logLines = 2000;
-        int lineLength = "echo line ".length() + String.valueOf(logLines).length() + "This is a very long log line that will be repeated many times to test truncation. Adding some extra system information here.\n".length();
-        StringBuilder script = new StringBuilder(logLines * lineLength);
-        String logSuffix = "This is a very long log line that will be repeated many times to test truncation. Adding some extra system information here.\n";
-        for (int i = 0; i < logLines; i++) {
-            script.append("echo line ").append(i).append(logSuffix);
-        }
         if (Functions.isWindows()) {
-            project.getBuildersList().add(new BatchFile(script.toString()));
+            project.getBuildersList().add(new BatchFile(log));
         }
         else {
-            project.getBuildersList().add(new Shell(script.toString()));
+            project.getBuildersList().add(new Shell(log));
         }
 
         buildSuccessfully(project);
@@ -475,10 +482,29 @@ class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest 
                 assertThat(summary).doesNotContain("Line 1:");  // Should be truncated from the start
                 // Verify the truncation message appears at the start of the log section
                 assertThat(summary).matches(Pattern.compile(".*<summary>Build Log</summary>\\s+\\n```\\s*\\nBuild log truncated.\\n\\n.*", Pattern.DOTALL));
-                // Verify the total size is within limits\
+                // Verify the total size is within limits
                 assertThat(summary.length()).isLessThanOrEqualTo(65_535);
             });
         });
+    }
+
+    private static String characterTruncationLog() {
+        int logLines = 1000;
+        String logSuffix = "This is a very long log line that will be repeated many times to test truncation. Adding some extra system information here.";
+        StringBuilder script = new StringBuilder(logLines * logSuffix.length() * 4);
+        for (int i = 0; i < logLines; i++) {
+            script.append("echo \"Line ").append(i).append(": ").append(logSuffix).append(logSuffix).append(logSuffix).append("\"\n");
+        }
+        return script.toString();
+    }
+
+    private static String lineTruncationLog() {
+        int logLines = 2000;
+        StringBuilder script = new StringBuilder(logLines * 100);
+        for (int i = 0; i < logLines; i++) {
+            script.append("echo \"Line ").append(i).append(": This is a test log line\"\n");
+        }
+        return script.toString();
     }
 
     /**


### PR DESCRIPTION
Support freestyle job logs in the in the checks API output.

Relevant issue: [421](https://github.com/jenkinsci/github-checks-plugin/issues/421)

Previously only pipeline jobs were supported for log, and freestyle jobs only had an in progress and success/failure state. This change adds a logs in a similar to how pipeline jobs for these freestyle jobs.

Attempted to do some refactoring into an Abstract class to reduce some de-duplication, but open to other ideas.

### Testing done
- Added relevant tests
- testing locally:
before:
<img width="1710" alt="Screenshot 2025-06-11 at 10 42 33 PM" src="https://github.com/user-attachments/assets/ea298197-a627-4dea-90d5-7670d0dd7668" />
after:
<img width="1704" alt="Screenshot 2025-06-11 at 10 18 53 PM" src="https://github.com/user-attachments/assets/d1475de6-eacc-4b6d-8144-34ce494d5a5d" />

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

cc: @sarahdeitke @timja 