### PR TITLE
Honor `skipProgressUpdates` for queued and checkout status publishes

### DIFF
--- a/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/AbstractStatusChecksProperties.java
@@ -64,8 +64,9 @@ public abstract class AbstractStatusChecksProperties implements ExtensionPoint {
     }
 
     /**
-     * Returns whether to suppress progress updates from the {@link io.jenkins.plugins.checks.status.FlowExecutionAnalyzer}.
-     * Queued, Checkout and Completed will still run but not 'onNewHead'
+     * Returns whether to suppress intermediate progress updates: the "queued" status published when the job is
+     * scheduled, the "in progress" status published after each SCM checkout, and the stage updates from the
+     * {@link io.jenkins.plugins.checks.status.FlowExecutionAnalyzer}. The final completed status is always published.
      *
      * @param job
      *         A jenkins job.

--- a/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisher.java
@@ -137,7 +137,7 @@ public final class BuildStatusChecksPublisher {
          * {@inheritDoc}
          *
          * <p>
-         * When a job enters queue, creates the check on "queued".
+         * When a job enters queue, creates the check on "queued", unless progress updates are skipped.
          * </p>
          */
         @Override
@@ -147,6 +147,10 @@ public final class BuildStatusChecksPublisher {
             }
 
             final Job<?, ?> job = (Job<?, ?>) wi.task;
+            if (findProperties(job).isSkipProgressUpdates(job)) {
+                return;
+            }
+
             getChecksName(job).ifPresent(checksName -> runAsync(() -> {
                 ChecksPublisher publisher = ChecksPublisherFactory.fromJob(job, TaskListener.NULL);
                 publish(publisher, ChecksStatus.QUEUED, ChecksConclusion.NONE, checksName, null);
@@ -169,13 +173,18 @@ public final class BuildStatusChecksPublisher {
          * {@inheritDoc}
          *
          * <p>
-         * When checkout finished, update the check to "in progress".
+         * When checkout finished, update the check to "in progress", unless progress updates are skipped.
          * </p>
          */
         @Override
         public void onCheckout(final Run<?, ?> run, final SCM scm, final FilePath workspace,
                                final TaskListener listener, @CheckForNull final File changelogFile,
                                @CheckForNull final SCMRevisionState pollingBaseline) {
+            Job<?, ?> job = run.getParent();
+            if (findProperties(job).isSkipProgressUpdates(job)) {
+                return;
+            }
+
             getChecksName(run).ifPresent(checksName -> publish(ChecksPublisherFactory.fromRun(run, listener),
                     ChecksStatus.IN_PROGRESS, ChecksConclusion.NONE, checksName, null));
         }

--- a/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
+++ b/src/test/java/io/jenkins/plugins/checks/status/BuildStatusChecksPublisherITest.java
@@ -150,6 +150,29 @@ class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest 
     }
 
     /**
+     * Tests that when progress updates are skipped, the only published status is the final completed one:
+     * nothing is published when the job is scheduled or when checkout finishes.
+     */
+    @Test
+    public void shouldOnlyPublishCompletedStatusWhenProgressUpdatesAreSkipped() throws Exception {
+        getProperties().setApplicable(true);
+        getProperties().setSkipped(false);
+        getProperties().setSkipProgressUpdates(true);
+        getProperties().setName("Test Status");
+
+        buildSuccessfully(createFreeStyleProject());
+        // Wait for the job to finish to work around slow Windows builds sometimes
+        this.getJenkins().waitUntilNoActivity();
+        assertThat(getFactory().getPublishedChecks()).hasSize(1);
+
+        ChecksDetails details = getFactory().getPublishedChecks().get(0);
+
+        assertThat(details.getName()).contains("Test Status");
+        assertThat(details.getStatus()).isEqualTo(ChecksStatus.COMPLETED);
+        assertThat(details.getConclusion()).isEqualTo(ChecksConclusion.SUCCESS);
+    }
+
+    /**
      * Test checks output includes pipeline details.
      */
     @Test
@@ -556,6 +579,7 @@ class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest 
         private boolean skipped;
         private String name;
         private boolean suppressLogs;
+        private boolean skipProgressUpdates;
 
         public void setApplicable(final boolean applicable) {
             this.applicable = applicable;
@@ -571,6 +595,10 @@ class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest 
 
         public void setSuppressLogs(final boolean suppressLogs) {
             this.suppressLogs = suppressLogs;
+        }
+
+        public void setSkipProgressUpdates(final boolean skipProgressUpdates) {
+            this.skipProgressUpdates = skipProgressUpdates;
         }
 
         @Override
@@ -591,6 +619,11 @@ class BuildStatusChecksPublisherITest extends IntegrationTestWithJenkinsPerTest 
         @Override
         public boolean isSuppressLogs(final Job<?, ?> job) {
             return suppressLogs;
+        }
+
+        @Override
+        public boolean isSkipProgressUpdates(final Job<?, ?> job) {
+            return skipProgressUpdates;
         }
     }
 }


### PR DESCRIPTION
When using this plugin on our repositories, the status report on Github sometimes is wrong and we end up having jobs that stay "in progress" forever.

This happens when a build runs several checkouts in quick succession: every checkout publishes an "in progress" status, and when two of those publishes land close enough together they each create their own check run on GitHub, of which only one gets completed at the end of the build. GitHub displays the newest run per check name, so the leftover duplicate can be what the PR shows, "in progress" forever.

The `skipProgressUpdates` option already exists to quiet intermediate reports, but it only covers stage updates ([JENKINS-65262](https://issues.jenkins.io/browse/JENKINS-65262) / #98), not the queued and per-checkout reports. This change makes the option cover those too: with it on, the final result is the only status published, so the racing publishes are gone. The javadoc is updated accordingly, and the option still defaults to false, so jobs that do not set it behave exactly as before.

### Testing done

A new integration test asserts that a build with the option on publishes exactly one status, the final completed one. `mvn test -Dtest=BuildStatusChecksPublisherITest` is green on Java 21, and the existing tests cover the default behavior (queued, in progress, and completed all still published when the option is off).

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
