### PR TITLE
Update Jenkins baseline to 2.555.3 and require Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 
     <testcontainers.version>2.0.5</testcontainers.version>
-    <jenkins.baseline>2.492</jenkins.baseline>
+    <jenkins.baseline>2.555</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
@@ -47,7 +47,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>5473.vb_9533d9e5d88</version>
+        <version>6931.vea_a_b_c6fd017d</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/test/java/io/jenkins/plugins/checks/ArchitectureTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/ArchitectureTest.java
@@ -5,7 +5,7 @@ import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
-import edu.hm.hafner.util.ArchitectureRules;
+import edu.hm.hafner.archunit.ArchitectureRules;
 import io.jenkins.plugins.util.PluginArchitectureRules;
 
 /**


### PR DESCRIPTION
Update the Jenkins baseline from 2.492.3 to 2.555.3, one of the [currently recommended versions](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions).

## What's changed

- `jenkins.baseline` 2.492 -> 2.555, and the plugin BOM to `bom-2.555.x`.
- `ArchitectureRules` moved from `edu.hm.hafner.util` to `edu.hm.hafner.archunit` in the `plugin-util-api` the newer BOM pulls in (6.1.0 -> 7.x). Import updated; every rule constant the test uses still exists under the new package.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk baseline update across the plugins I maintain. If anything here looks wrong, please comment on this PR.
